### PR TITLE
Updated sparse bit set specification section.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -79,15 +79,15 @@ should be encoded by CBOR are given in the definition of those data types.
 ### SparseBitSet ### {#sparsebitset}
 
 A data structure which compactly stores a set of distinct unsigned integers. The set is represented as
-an tree where each node has a fixed number of children that recursively sub-divides an interval into
+a tree where each node has a fixed number of children that recursively sub-divides an interval into
 equal partitions. A tree of height <i>H</i> with branching factor <i>B</i> can store set membership
 for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree is encoded into
 a ByteString for transport.
 
 To construct the tree <i>T</i> which encodes set <i>S</i> first select the branching factor <i>B</i>
-(how many children each node has). <i>B</i> can be 4, 8, 16, or 32.
+(how many children each node has). <i>B</i> can be 4, 8, 16, or 32. 
 
-Note: that while the encoder can use any of the possible branching factors, but it is recommended to
+Note: the encoder can use any of the possible branching factors, but it is recommended to
 use 4 as that has been shown to give the smallest encodings for most sets typically encountered.
 
 Next, determine the height, <i>H</i>, of the tree:
@@ -126,7 +126,7 @@ The tree is encoded into a bit string. The bits of the bit string are numbered f
 appending multi bit values to the bit string, bits are added in order from least significant bit to
 most significant bit.
 
-To encode tree <i>T</i> into a bit string first append 2 bits which encode the branching factor:
+First append 2 bits which encode the branching factor:
 
 <table>
   <tr>
@@ -141,13 +141,13 @@ To encode tree <i>T</i> into a bit string first append 2 bits which encode the b
 Then append the value <i>H</i> - 1 as a 6 bit unsigned integer.
 
 Next the nodes are encoded into the bit string by traversing the nodes of the <i>T</i> in level
-order and appending the value for each node to the bit string. If all set values covered by a node's
-interval are present within set <i>S</i> that node can instead be encoded in the ByteString as <i>B</i>
-bits all set to zero. Additionally all children of that node must not be encoded.
+order and appending the value for each non-zero node to the bit string.If all set values
+covered by a node's interval are present within set <i>S</i> that node can instead be encoded in the
+bit string as <i>B</i> bits all set to zero. All children of that node must not be encoded.
 
-Lastly the bit string is converted into a ByteString by converting each subsequent group of 8 bits
-into a byte. The lower bit index is the least significant bit and the highest bit index is the
-most significant bit.
+Lastly the bit string is converted into a ByteString by converting each consecutive group of 8 bits
+into the next byte of the string. The bit with the smallest index in the bit string is the least
+significant bit in the byte and the bit with the largest index is the most significant bit.
 
 
 <div class=example>

--- a/Overview.bs
+++ b/Overview.bs
@@ -94,8 +94,6 @@ Next, determine the height, <i>H</i>, of the tree:
 
 <i>H</i> = ceil(log<sub><i>B</i></sub>(max(</i>S</i>) + 1))
 
-TODO(garretrieger): tree height needs update.
-
 Next create a tree of height H where all non-leaf nodes have <i>B</i> children. Each node in the tree
 has a single value composed of <i>B</i> bits. Given a node <i>p</i> which has <i>B</i> children:
 <i>c<sub>0</sub></i> ... <i>c<sub><i>B</i> - 1</sub></i> and is in a tree, <i>T</i>, of height
@@ -121,9 +119,8 @@ has a single value composed of <i>B</i> bits. Given a node <i>p</i> which has <i
     contains at least one member in the interval [Start(<i>c<sub>i</sub></i>),
     End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.
 
-*  If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = 1, then <i>p</i> will have no children
-    and its value is 0.
-
+*  If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = <i>B</i>, then <i>p</i> will have no
+    children.
 
 The tree is encoded into a bit string. The bits of the bit string are numbered from 0 to M. When
 appending multi bit values to the bit string, bits are added in order from least significant bit to
@@ -162,7 +159,8 @@ most significant bit.
   |         |   n0   |   n1       n2   |   n3       n4       n5    |
   [ 10010000 10000100 10001000 10000000 00100000 01000000 00010000 ]
 
-  ByteString = [
+  Which then becomes the ByteString:
+  [
     0b00001001,
     0b00100001,
     0b00010001,
@@ -182,25 +180,27 @@ most significant bit.
   *  branching factor = 8 = 01
   *  <i>H</i> - 1 = 2 = 000010
 
-  The value of the root node, n<sub>0</sub>, is 00100001 since there are set members in the intervals
-  [0, 64) for bit 0 and [320, 384) for bit 5.
-
-  In the next level of the tree there will be two non-zero children corresponding to bit 0
-  and bit 5 in n<sub>0</sub>:
-
-  * 00010001 is child 0 of n<sub>0</sub> it subdivides the interval [0, 64). Bit 0 is set
-     since there are set members in [0, 8) and bit 4 for [32, 40).
+  Level 0:
   
-  * 10000000 is child 5 of n<sub>0</sub> it subdivides the interval [320, 384). Bit 0 is
-     set since there are set members in [320 - 328).
+  * root node, n<sub>0</sub> append 00100001. Since there are set members in the intervals
+     [0, 64) for bit 0 and [320, 384) for bit 5.
+
+  Level 1:
   
-  Finally the last nodes are 00100000, 01000000, 00010000 which represent
-  the non-zero children in the third level of the tree:
+  * There will be two non-zero children corresponding to bit 0 and bit 5 in n<sub>0</sub>:
+  * n<sub>1</sub> append 00010001. It is child 0 of n<sub>0</sub> and subdivides the interval
+     [0, 64). Bit 0 is set since there are set members in [0, 8) and bit 4 for [32, 40).
+  
+  * n<sub>2</sub> append 00000001. It is child 5 of n<sub>0</sub> it subdivides the interval
+     [320, 384). Bit 0 is set since there are set members in [320 - 328).
 
-  * 00000100 is child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.
-  * 00000010 is child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.
-  * 00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.
+  Level 2:
 
+  * n<sub>3</sub> append 00000100. Child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.
+  * n<sub>4</sub> append 00000010. Child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.
+  * n<sub>5</sub> append 00001000. Child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324)
+     or 323.
+     
 </div>
 
 <div class=example>
@@ -212,7 +212,8 @@ most significant bit.
   |         | n0 | n1 | n2 | n3  |
   [ 00010000 1100 0000 1000 1100 ]
 
-  ByteString = [
+  ByteString:
+  [
     0b00001000,
     0b00000011,
     0b00110001
@@ -229,14 +230,14 @@ most significant bit.
   *  <i>H</i> - 1 = 2 = 000010
 
   Level 0:
-  *  n0 = bit 0 set for [0, 16), bit 1 set for [16, 32)
+  *  n<sub>0</sub> append 0011. Bit 0 set for [0, 16), bit 1 set for [16, 32)
 
   Level 1:
-  *  n1 = all bits zero to indicate interval [0, 16) is fully filled.
-  *  n2 = bit 0 set for [16, 20)
+  *  n<sub>1</sub> append 0000. All bits zero to indicate interval [0, 16) is fully filled.
+  *  n<sub>2</sub> append 0001. Bit 0 set for [16, 20)
 
   Level 2:
-  *  n3 = bit 0 set for value 16, bit 1 set for value 17.
+  *  n<sub>3</sub> append 0011. Bit 0 set for value 16, bit 1 set for value 17.
 
 </div>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: Progressive Font Enrichment, or whatever we call it
+Title: Incremental Font Transfer
 Shortname: PFE
 Status: w3c/ED
 Group: webfontswg
@@ -8,7 +8,7 @@ TR: https://www.w3.org/TR/example/
 ED: https://w3c.github.io/PFE/Overview.html
 Editor: Chris Lilley, W3C, https://svgees.us/, w3cid 1438
 Editor: Myles C. Maxfield, Apple Inc., mmaxfield@apple.com, w3cid 77180
-Editor: Garret Rieger, Google Inc., http://example.com/contact
+Editor: Garret Rieger, Google Inc., grieger@google.com
 Abstract: Example example
 Status Text: This is a largely empty document because we have just started working on it.
 </pre>
@@ -79,18 +79,27 @@ should be encoded by CBOR are given in the definition of those data types.
 ### SparseBitSet ### {#sparsebitset}
 
 A data structure which compactly stores a set of distinct unsigned integers. The set is represented as
-an oct-tree where each node has 8 children that recursively sub-divides an interval into 8 equal
-partitions. A tree of height <i>H</i> can store set membership for integers in the interval [0 to
-8<sup><i>H</i></sup>-1] inclusive. The tree is encoded into a ByteString for transport.
+an tree where each node has a fixed number of children that recursively sub-divides an interval into
+equal partitions. A tree of height <i>H</i> with branching factor <i>B</i> can store set membership
+for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree is encoded into
+a ByteString for transport.
 
-To construct the tree <i>T</i> which encodes set <i>S</i> first determine the height, <i>H</i>, of the
-tree:
+To construct the tree <i>T</i> which encodes set <i>S</i> first select the branching factor <i>B</i>
+(how many children each node has). <i>B</i> can be 4, 8, 16, or 32.
 
-<i>H</i> = ceil(log<sub>8</sub>(max(</i>S</i>) + 1))
+Note: the encoder is free to use any of the possible branching factors, but should try to pick one
+that will give this smallest encoding. It's likely that a heuristic based on the set size and/or
+maximum value will generally select a good branching factor. Alternatively, the encoder could test
+encoding with the various branching factors and keep the encoding which is the smallest.
 
-Next create a tree of height H where all non-leaf nodes have 8 children. Each node in the tree has
-a single byte value. Given a node <i>p</i> which has 8 children:
-<i>c<sub>0</sub></i> ... <i>c<sub>7</sub></i> and is in a tree, <i>T</i>, of height <i>H</i>, then:
+Next, determine the height, <i>H</i>, of the tree:
+
+<i>H</i> = ceil(log<sub><i>B</i></sub>(max(</i>S</i>) + 1))
+
+Next create a tree of height H where all non-leaf nodes have <i>B</i> children. Each node in the tree
+has a single value composed of <i>B</i> bits. Given a node <i>p</i> which has <i>B</i> children:
+<i>c<sub>0</sub></i> ... <i>c<sub><i>B</i> - 1</sub></i> and is in a tree, <i>T</i>, of height
+<i>H</i>, then:
 
 *  D(<i>c<sub>i</sub></i>) is depth of node <i>c<sub>i</sub></i>, that is the number of edges between
     the root node and <i>c<sub>i</sub></i>.
@@ -98,29 +107,32 @@ a single byte value. Given a node <i>p</i> which has 8 children:
 *  Start(<i>c<sub>i</sub></i>) is the start (inclusive) of the interval  covered by
      <i>c<sub>i</sub></i> :<br/>
      Start(<i>c<sub>i</sub></i>) =
-     Start(<i>p</i>) + <i>i</i> * 8<sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup>
+     Start(<i>p</i>) + <i>i</i> * <i>B</i><sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup>
      
 *  End(<i>c<sub>i</sub></i>) is the end (exclusive) of the interval  covered by
      <i>c<sub>i</sub></i> :<br/>
      End(<i>c<sub>i</sub></i>) =
-     Start(<i>p</i>) + (<i>i</i> + 1) * 8<sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup>
+     Start(<i>p</i>) + (<i>i</i> + 1) * <i>B</i><sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup>
 
 *  Start(root node) = 0
      
-*  The value of node <i>p</i> is as a single byte (8 bits). If its bits are numbered from 0
-    (least significant bit) to 7 (most significant bit) then bit <i>i</i> will be 1 if the
+*  The value of node <i>p</i> is composted of <i>B</i> bits. If its bits are numbered from 0
+    (least significant bit) to <i>B</i> - 1 (most significant bit) then bit <i>i</i> will be 1 if the
     set <i>S</i> contains at least one member in the interval
     [Start(<i>c<sub>i</sub></i>), End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.
 
 *  If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = 1, then <i>p</i> will have no children
-    and its value byte is 0.
+    and its value is 0.
 
 Finally, tree <i>T</i> is encoded into a ByteString by traversing the nodes of the <i>T</i> in level
-order and appending the value byte for each node to the ByteString if the value byte has a non-zero
+order and appending the value for each node to the ByteString if the value has a non-zero
 value.
 
+TODO(garretrieger): add info on the first byte which encodes BF and depth.
+TODO(garretrieger): add info on replacing a fully filled sub-tree with a 0 value.
+
 <div class=example>
-  The set {2, 33, 323} is encoded as the byte string:
+  The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the byte string:
   
   ```
   |- level 0 -|------ level 1 --------|----------- level 2 ----------------|
@@ -151,6 +163,15 @@ value.
   * 0b00000010 is child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.
   * 0b00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.
 
+
+</div>
+
+<div class=example>
+  The set {2, 33, 323} in a tree with a branching factor of 4 is encoded as the byte string:
+
+  ```
+  TODO(garretrieger): update this example for BF4.
+  ```
 </div>
 
 ### Objects ### {#objects}

--- a/Overview.bs
+++ b/Overview.bs
@@ -87,14 +87,14 @@ a ByteString for transport.
 To construct the tree <i>T</i> which encodes set <i>S</i> first select the branching factor <i>B</i>
 (how many children each node has). <i>B</i> can be 4, 8, 16, or 32.
 
-Note: the encoder is free to use any of the possible branching factors, but should try to pick one
-that will give this smallest encoding. It's likely that a heuristic based on the set size and/or
-maximum value will generally select a good branching factor. Alternatively, the encoder could test
-encoding with the various branching factors and keep the encoding which is the smallest.
+Note: that while the encoder can use any of the possible branching factors, but it is recommended to
+use 4 as that has been shown to give the smallest encodings for most sets typically encountered.
 
 Next, determine the height, <i>H</i>, of the tree:
 
 <i>H</i> = ceil(log<sub><i>B</i></sub>(max(</i>S</i>) + 1))
+
+TODO(garretrieger): tree height needs update.
 
 Next create a tree of height H where all non-leaf nodes have <i>B</i> children. Each node in the tree
 has a single value composed of <i>B</i> bits. Given a node <i>p</i> which has <i>B</i> children:
@@ -116,62 +116,128 @@ has a single value composed of <i>B</i> bits. Given a node <i>p</i> which has <i
 
 *  Start(root node) = 0
      
-*  The value of node <i>p</i> is composted of <i>B</i> bits. If its bits are numbered from 0
-    (least significant bit) to <i>B</i> - 1 (most significant bit) then bit <i>i</i> will be 1 if the
-    set <i>S</i> contains at least one member in the interval
-    [Start(<i>c<sub>i</sub></i>), End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.
+*  The value of node <i>p</i> is a string of <i>B</i> bits. If its bits are numbered from 0 (least
+    significant) to <i>B</i> - 1 (most significant) then bit <i>i</i> will be 1 if the set <i>S</i>
+    contains at least one member in the interval [Start(<i>c<sub>i</sub></i>),
+    End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.
 
 *  If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = 1, then <i>p</i> will have no children
     and its value is 0.
 
-Finally, tree <i>T</i> is encoded into a ByteString by traversing the nodes of the <i>T</i> in level
-order and appending the value for each node to the ByteString if the value has a non-zero
-value.
 
-TODO(garretrieger): add info on the first byte which encodes BF and depth.
-TODO(garretrieger): add info on replacing a fully filled sub-tree with a 0 value.
+The tree is encoded into a bit string. The bits of the bit string are numbered from 0 to M. When
+appending multi bit values to the bit string, bits are added in order from least significant bit to
+most significant bit.
+
+To encode tree <i>T</i> into a bit string first append 2 bits which encode the branching factor:
+
+<table>
+  <tr>
+    <th>Bits</th><th>Branching Factor</th>
+  </tr>
+  <tr><td>00</td><td>4</td></tr>
+  <tr><td>01</td><td>8</td></tr>
+  <tr><td>10</td><td>16</td></tr>
+  <tr><td>11</td><td>32</td></tr>
+</table>
+
+Then append the value <i>H</i> - 1 as a 6 bit unsigned integer.
+
+Next the nodes are encoded into the bit string by traversing the nodes of the <i>T</i> in level
+order and appending the value for each node to the bit string. If all set values covered by a node's
+interval are present within set <i>S</i> that node can instead be encoded in the ByteString as <i>B</i>
+bits all set to zero. Additionally all children of that node must not be encoded.
+
+Lastly the bit string is converted into a ByteString by converting each subsequent group of 8 bits
+into a byte. The lower bit index is the least significant bit and the highest bit index is the
+most significant bit.
+
 
 <div class=example>
-  The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the byte string:
+  The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the bit string:
   
   ```
-  |- level 0 -|------ level 1 --------|----------- level 2 ----------------|
-  |     n0    |     n1          n2    |      n3         n4          n5     |
-  [ 0b00100001, 0b00010001, 0b00000001, 0b00000100, 0b00000010, 0b00001000 ]
+  BitString:
+  |- header |- lvl 0 |---- level 1 ----|------- level 2 -----------|
+  |         |   n0   |   n1       n2   |   n3       n4       n5    |
+  [ 10010000 10000100 10001000 10000000 00100000 01000000 00010000 ]
+
+  ByteString = [
+    0b00001001,
+    0b00100001,
+    0b00010001,
+    0b00000001,
+    0b00000100,
+    0b00000010,
+    0b00001000
+  ]
   ```
   
   First determine the height of the tree:
   
   <i>H</i> = ceil(log<sub>8</sub>(323 + 1)) = 3
 
-  The value of the root node, n<sub>0</sub>, is 0b00100001 since there are set members in the intervals
+  Then append
+
+  *  branching factor = 8 = 01
+  *  <i>H</i> - 1 = 2 = 000010
+
+  The value of the root node, n<sub>0</sub>, is 00100001 since there are set members in the intervals
   [0, 64) for bit 0 and [320, 384) for bit 5.
 
   In the next level of the tree there will be two non-zero children corresponding to bit 0
   and bit 5 in n<sub>0</sub>:
 
-  * 0b00010001 is child 0 of n<sub>0</sub> it subdivides the interval [0, 64). Bit 0 is set
+  * 00010001 is child 0 of n<sub>0</sub> it subdivides the interval [0, 64). Bit 0 is set
      since there are set members in [0, 8) and bit 4 for [32, 40).
   
-  * 0b10000000 is child 5 of n<sub>0</sub> it subdivides the interval [320, 384). Bit 0 is
+  * 10000000 is child 5 of n<sub>0</sub> it subdivides the interval [320, 384). Bit 0 is
      set since there are set members in [320 - 328).
   
-  Finally the last 3 bytes 0b00100000, 0b01000000, 0b00010000 represent
+  Finally the last nodes are 00100000, 01000000, 00010000 which represent
   the non-zero children in the third level of the tree:
 
-  * 0b00000100 is child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.
-  * 0b00000010 is child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.
-  * 0b00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.
-
+  * 00000100 is child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.
+  * 00000010 is child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.
+  * 00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.
 
 </div>
 
 <div class=example>
-  The set {2, 33, 323} in a tree with a branching factor of 4 is encoded as the byte string:
+  The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as:
 
   ```
-  TODO(garretrieger): update this example for BF4.
+  BitString:
+  |- header | l0 |- lvl 1 -| l2  |
+  |         | n0 | n1 | n2 | n3  |
+  [ 00010000 1100 0000 1000 1100 ]
+
+  ByteString = [
+    0b00001000,
+    0b00000011,
+    0b00110001
+  ]
   ```
+
+  First determine the height of the tree:
+  
+  <i>H</i> = ceil(log<sub>4</sub>(17 + 1)) = 3
+
+  Then append
+  
+  *  branching factor = 4 = 00
+  *  <i>H</i> - 1 = 2 = 000010
+
+  Level 0:
+  *  n0 = bit 0 set for [0, 16), bit 1 set for [16, 32)
+
+  Level 1:
+  *  n1 = all bits zero to indicate interval [0, 16) is fully filled.
+  *  n2 = bit 0 set for [16, 20)
+
+  Level 2:
+  *  n3 = bit 0 set for value 16, bit 1 set for value 17.
+
 </div>
 
 ### Objects ### {#objects}

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version b94c7e755, updated Fri Feb 19 16:28:59 2021 -0800" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="12c8ba39ec8f6f6e10ed5481a7a797abd5bfdd50" name="document-revision">
+  <meta content="ea3b40b12d03ba801f341310680329b95822a917" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-03-19">19 March 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-03-22">22 March 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -589,8 +589,8 @@ the root node and <i>c<sub>i</sub></i>.</p>
 significant) to <i>B</i> - 1 (most significant) then bit <i>i</i> will be 1 if the set <i>S</i> contains at least one member in the interval [Start(<i>c<sub>i</sub></i>),
 End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.</p>
     <li data-md>
-     <p>If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = 1, then <i>p</i> will have no children
-and its value is 0.</p>
+     <p>If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = <i>B</i>, then <i>p</i> will have no
+children.</p>
    </ul>
    <p>The tree is encoded into a bit string. The bits of the bit string are numbered from 0 to M. When
 appending multi bit values to the bit string, bits are added in order from least significant bit to
@@ -621,14 +621,15 @@ interval are present within set <i>S</i> that node can instead be encoded in the
    <p>Lastly the bit string is converted into a ByteString by converting each subsequent group of 8 bits
 into a byte. The lower bit index is the least significant bit and the highest bit index is the
 most significant bit.</p>
-   <div class="example" id="example-2e57550e">
-    <a class="self-link" href="#example-2e57550e"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the bit string: 
+   <div class="example" id="example-76606ecb">
+    <a class="self-link" href="#example-76606ecb"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the bit string: 
 <pre>  BitString:
   |- header |- lvl 0 |---- level 1 ----|------- level 2 -----------|
   |         |   n0   |   n1       n2   |   n3       n4       n5    |
   [ 10010000 10000100 10001000 10000000 00100000 01000000 00010000 ]
 
-  ByteString = [
+  Which then becomes the ByteString:
+  [
     0b00001001,
     0b00100001,
     0b00010001,
@@ -647,37 +648,43 @@ most significant bit.</p>
      <li data-md>
       <p><i>H</i> - 1 = 2 = 000010</p>
     </ul>
-    <p>The value of the root node, n<sub>0</sub>, is 00100001 since there are set members in the intervals
-  [0, 64) for bit 0 and [320, 384) for bit 5.</p>
-    <p>In the next level of the tree there will be two non-zero children corresponding to bit 0
-  and bit 5 in n<sub>0</sub>:</p>
+    <p>Level 0:</p>
     <ul>
      <li data-md>
-      <p>00010001 is child 0 of n<sub>0</sub> it subdivides the interval [0, 64). Bit 0 is set
- since there are set members in [0, 8) and bit 4 for [32, 40).</p>
-     <li data-md>
-      <p>10000000 is child 5 of n<sub>0</sub> it subdivides the interval [320, 384). Bit 0 is
- set since there are set members in [320 - 328).</p>
+      <p>root node, n<sub>0</sub> append 00100001. Since there are set members in the intervals
+ [0, 64) for bit 0 and [320, 384) for bit 5.</p>
     </ul>
-    <p>Finally the last nodes are 00100000, 01000000, 00010000 which represent
-  the non-zero children in the third level of the tree:</p>
+    <p>Level 1:</p>
     <ul>
      <li data-md>
-      <p>00000100 is child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.</p>
+      <p>There will be two non-zero children corresponding to bit 0 and bit 5 in n<sub>0</sub>:</p>
      <li data-md>
-      <p>00000010 is child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.</p>
+      <p>n<sub>1</sub> append 00010001. It is child 0 of n<sub>0</sub> and subdivides the interval
+ [0, 64). Bit 0 is set since there are set members in [0, 8) and bit 4 for [32, 40).</p>
      <li data-md>
-      <p>00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.</p>
+      <p>n<sub>2</sub> append 00000001. It is child 5 of n<sub>0</sub> it subdivides the interval
+ [320, 384). Bit 0 is set since there are set members in [320 - 328).</p>
+    </ul>
+    <p>Level 2:</p>
+    <ul>
+     <li data-md>
+      <p>n<sub>3</sub> append 00000100. Child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.</p>
+     <li data-md>
+      <p>n<sub>4</sub> append 00000010. Child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.</p>
+     <li data-md>
+      <p>n<sub>5</sub> append 00001000. Child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324)
+ or 323.</p>
     </ul>
    </div>
-   <div class="example" id="example-ccb34548">
-    <a class="self-link" href="#example-ccb34548"></a> The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as: 
+   <div class="example" id="example-88b1de08">
+    <a class="self-link" href="#example-88b1de08"></a> The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as: 
 <pre>  BitString:
   |- header | l0 |- lvl 1 -| l2  |
   |         | n0 | n1 | n2 | n3  |
   [ 00010000 1100 0000 1000 1100 ]
 
-  ByteString = [
+  ByteString:
+  [
     0b00001000,
     0b00000011,
     0b00110001
@@ -695,19 +702,19 @@ most significant bit.</p>
     <p>Level 0:</p>
     <ul>
      <li data-md>
-      <p>n0 = bit 0 set for [0, 16), bit 1 set for [16, 32)</p>
+      <p>n<sub>0</sub> append 0011. Bit 0 set for [0, 16), bit 1 set for [16, 32)</p>
     </ul>
     <p>Level 1:</p>
     <ul>
      <li data-md>
-      <p>n1 = all bits zero to indicate interval [0, 16) is fully filled.</p>
+      <p>n<sub>1</sub> append 0000. All bits zero to indicate interval [0, 16) is fully filled.</p>
      <li data-md>
-      <p>n2 = bit 0 set for [16, 20)</p>
+      <p>n<sub>2</sub> append 0001. Bit 0 set for [16, 20)</p>
     </ul>
     <p>Level 2:</p>
     <ul>
      <li data-md>
-      <p>n3 = bit 0 set for value 16, bit 1 set for value 17.</p>
+      <p>n<sub>3</sub> append 0011. Bit 0 set for value 16, bit 1 set for value 17.</p>
     </ul>
    </div>
    <h4 class="heading settled" data-level="2.1.4" id="objects"><span class="secno">2.1.4. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version b94c7e755, updated Fri Feb 19 16:28:59 2021 -0800" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="d18487261d63a92e8fbdb7ad77187972cd8fa4c5" name="document-revision">
+  <meta content="12c8ba39ec8f6f6e10ed5481a7a797abd5bfdd50" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-03-15">15 March 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-03-19">19 March 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -566,10 +566,8 @@ equal partitions. A tree of height <i>H</i> with branching factor <i>B</i> can s
 for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree is encoded into
 a ByteString for transport.</p>
    <p>To construct the tree <i>T</i> which encodes set <i>S</i> first select the branching factor <i>B</i> (how many children each node has). <i>B</i> can be 4, 8, 16, or 32.</p>
-   <p class="note" role="note"><span>Note:</span> the encoder is free to use any of the possible branching factors, but should try to pick one
-that will give this smallest encoding. It’s likely that a heuristic based on the set size and/or
-maximum value will generally select a good branching factor. Alternatively, the encoder could test
-encoding with the various branching factors and keep the encoding which is the smallest.</p>
+   <p class="note" role="note"><span>Note:</span> that while the encoder can use any of the possible branching factors, but it is recommended to
+use 4 as that has been shown to give the smallest encodings for most sets typically encountered.</p>
    <p>Next, determine the height, <i>H</i>, of the tree:</p>
    <p><i>H</i> = ceil(log<sub><i>B</i></sub>(max(S) + 1))</p>
    <p>Next create a tree of height H where all non-leaf nodes have <i>B</i> children. Each node in the tree
@@ -587,54 +585,130 @@ the root node and <i>c<sub>i</sub></i>.</p>
     <li data-md>
      <p>Start(root node) = 0</p>
     <li data-md>
-     <p>The value of node <i>p</i> is composted of <i>B</i> bits. If its bits are numbered from 0
-(least significant bit) to <i>B</i> - 1 (most significant bit) then bit <i>i</i> will be 1 if the
-set <i>S</i> contains at least one member in the interval
-[Start(<i>c<sub>i</sub></i>), End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.</p>
+     <p>The value of node <i>p</i> is a string of <i>B</i> bits. If its bits are numbered from 0 (least
+significant) to <i>B</i> - 1 (most significant) then bit <i>i</i> will be 1 if the set <i>S</i> contains at least one member in the interval [Start(<i>c<sub>i</sub></i>),
+End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.</p>
     <li data-md>
      <p>If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = 1, then <i>p</i> will have no children
 and its value is 0.</p>
    </ul>
-   <p>Finally, tree <i>T</i> is encoded into a ByteString by traversing the nodes of the <i>T</i> in level
-order and appending the value for each node to the ByteString if the value has a non-zero
-value.</p>
-   <p>TODO(garretrieger): add info on the first byte which encodes BF and depth.
-TODO(garretrieger): add info on replacing a fully filled sub-tree with a 0 value.</p>
-   <div class="example" id="example-a03bf883">
-    <a class="self-link" href="#example-a03bf883"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the byte string: 
-<pre>  |- level 0 -|------ level 1 --------|----------- level 2 ----------------|
-  |     n0    |     n1          n2    |      n3         n4          n5     |
-  [ 0b00100001, 0b00010001, 0b00000001, 0b00000100, 0b00000010, 0b00001000 ]
+   <p>The tree is encoded into a bit string. The bits of the bit string are numbered from 0 to M. When
+appending multi bit values to the bit string, bits are added in order from least significant bit to
+most significant bit.</p>
+   <p>To encode tree <i>T</i> into a bit string first append 2 bits which encode the branching factor:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Bits
+      <th>Branching Factor
+     <tr>
+      <td>00
+      <td>4
+     <tr>
+      <td>01
+      <td>8
+     <tr>
+      <td>10
+      <td>16
+     <tr>
+      <td>11
+      <td>32
+   </table>
+   <p>Then append the value <i>H</i> - 1 as a 6 bit unsigned integer.</p>
+   <p>Next the nodes are encoded into the bit string by traversing the nodes of the <i>T</i> in level
+order and appending the value for each node to the bit string. If all set values covered by a node’s
+interval are present within set <i>S</i> that node can instead be encoded in the ByteString as <i>B</i> bits all set to zero. Additionally all children of that node must not be encoded.</p>
+   <p>Lastly the bit string is converted into a ByteString by converting each subsequent group of 8 bits
+into a byte. The lower bit index is the least significant bit and the highest bit index is the
+most significant bit.</p>
+   <div class="example" id="example-2e57550e">
+    <a class="self-link" href="#example-2e57550e"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the bit string: 
+<pre>  BitString:
+  |- header |- lvl 0 |---- level 1 ----|------- level 2 -----------|
+  |         |   n0   |   n1       n2   |   n3       n4       n5    |
+  [ 10010000 10000100 10001000 10000000 00100000 01000000 00010000 ]
+
+  ByteString = [
+    0b00001001,
+    0b00100001,
+    0b00010001,
+    0b00000001,
+    0b00000100,
+    0b00000010,
+    0b00001000
+  ]
 </pre>
     <p>First determine the height of the tree:</p>
     <p><i>H</i> = ceil(log<sub>8</sub>(323 + 1)) = 3</p>
-    <p>The value of the root node, n<sub>0</sub>, is 0b00100001 since there are set members in the intervals
+    <p>Then append</p>
+    <ul>
+     <li data-md>
+      <p>branching factor = 8 = 01</p>
+     <li data-md>
+      <p><i>H</i> - 1 = 2 = 000010</p>
+    </ul>
+    <p>The value of the root node, n<sub>0</sub>, is 00100001 since there are set members in the intervals
   [0, 64) for bit 0 and [320, 384) for bit 5.</p>
     <p>In the next level of the tree there will be two non-zero children corresponding to bit 0
   and bit 5 in n<sub>0</sub>:</p>
     <ul>
      <li data-md>
-      <p>0b00010001 is child 0 of n<sub>0</sub> it subdivides the interval [0, 64). Bit 0 is set
+      <p>00010001 is child 0 of n<sub>0</sub> it subdivides the interval [0, 64). Bit 0 is set
  since there are set members in [0, 8) and bit 4 for [32, 40).</p>
      <li data-md>
-      <p>0b10000000 is child 5 of n<sub>0</sub> it subdivides the interval [320, 384). Bit 0 is
+      <p>10000000 is child 5 of n<sub>0</sub> it subdivides the interval [320, 384). Bit 0 is
  set since there are set members in [320 - 328).</p>
     </ul>
-    <p>Finally the last 3 bytes 0b00100000, 0b01000000, 0b00010000 represent
+    <p>Finally the last nodes are 00100000, 01000000, 00010000 which represent
   the non-zero children in the third level of the tree:</p>
     <ul>
      <li data-md>
-      <p>0b00000100 is child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.</p>
+      <p>00000100 is child 0 of n<sub>1</sub>, bit 2 is set for the interval [2, 3) or 2.</p>
      <li data-md>
-      <p>0b00000010 is child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.</p>
+      <p>00000010 is child 4 of n<sub>1</sub>, bit 1 is set for the interval [33, 34) or 33.</p>
      <li data-md>
-      <p>0b00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.</p>
+      <p>00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.</p>
     </ul>
    </div>
-   <div class="example" id="example-b3fa4470">
-    <a class="self-link" href="#example-b3fa4470"></a> The set {2, 33, 323} in a tree with a branching factor of 4 is encoded as the byte string: 
-<pre>  TODO(garretrieger): update this example for BF4.
+   <div class="example" id="example-ccb34548">
+    <a class="self-link" href="#example-ccb34548"></a> The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as: 
+<pre>  BitString:
+  |- header | l0 |- lvl 1 -| l2  |
+  |         | n0 | n1 | n2 | n3  |
+  [ 00010000 1100 0000 1000 1100 ]
+
+  ByteString = [
+    0b00001000,
+    0b00000011,
+    0b00110001
+  ]
 </pre>
+    <p>First determine the height of the tree:</p>
+    <p><i>H</i> = ceil(log<sub>4</sub>(17 + 1)) = 3</p>
+    <p>Then append</p>
+    <ul>
+     <li data-md>
+      <p>branching factor = 4 = 00</p>
+     <li data-md>
+      <p><i>H</i> - 1 = 2 = 000010</p>
+    </ul>
+    <p>Level 0:</p>
+    <ul>
+     <li data-md>
+      <p>n0 = bit 0 set for [0, 16), bit 1 set for [16, 32)</p>
+    </ul>
+    <p>Level 1:</p>
+    <ul>
+     <li data-md>
+      <p>n1 = all bits zero to indicate interval [0, 16) is fully filled.</p>
+     <li data-md>
+      <p>n2 = bit 0 set for [16, 20)</p>
+    </ul>
+    <p>Level 2:</p>
+    <ul>
+     <li data-md>
+      <p>n3 = bit 0 set for value 16, bit 1 set for value 17.</p>
+    </ul>
    </div>
    <h4 class="heading settled" data-level="2.1.4" id="objects"><span class="secno">2.1.4. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
    <p>Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps

--- a/Overview.html
+++ b/Overview.html
@@ -2,12 +2,12 @@
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <title>Progressive Font Enrichment, or whatever we call it</title>
+  <title>Incremental Font Transfer</title>
   <meta content="w3c/ED" name="w3c-status">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version b94c7e755, updated Fri Feb 19 16:28:59 2021 -0800" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="a83bdc1941817c3566d78c13fdeecaf266ef6b62" name="document-revision">
+  <meta content="d18487261d63a92e8fbdb7ad77187972cd8fa4c5" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -394,8 +394,8 @@ dfn > a.self-link::before      { content: "#"; }
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
-   <h1 class="p-name no-ref" id="title">Progressive Font Enrichment, or whatever we call it</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-02-25">25 February 2021</time></span></h2>
+   <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-03-15">15 March 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -410,7 +410,7 @@ dfn > a.self-link::before      { content: "#"; }
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="1438"><a class="p-name fn u-url url" href="https://svgees.us/">Chris Lilley</a> (<span class="p-org org">W3C</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="77180"><a class="p-name fn u-email email" href="mailto:mmaxfield@apple.com">Myles C. Maxfield</a> (<span class="p-org org">Apple Inc.</span>)
-     <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="http://example.com/contact">Garret Rieger</a> (<span class="p-org org">Google Inc.</span>)
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:grieger@google.com">Garret Rieger</a> (<span class="p-org org">Google Inc.</span>)
     </dl>
    </div>
    <div data-fill-with="warning"></div>
@@ -561,40 +561,47 @@ should be encoded by CBOR are given in the definition of those data types.</p>
    </table>
    <h4 class="heading settled" data-level="2.1.3" id="sparsebitset"><span class="secno">2.1.3. </span><span class="content">SparseBitSet</span><a class="self-link" href="#sparsebitset"></a></h4>
    <p>A data structure which compactly stores a set of distinct unsigned integers. The set is represented as
-an oct-tree where each node has 8 children that recursively sub-divides an interval into 8 equal
-partitions. A tree of height <i>H</i> can store set membership for integers in the interval [0 to
-8<sup><i>H</i></sup>-1] inclusive. The tree is encoded into a ByteString for transport.</p>
-   <p>To construct the tree <i>T</i> which encodes set <i>S</i> first determine the height, <i>H</i>, of the
-tree:</p>
-   <p><i>H</i> = ceil(log<sub>8</sub>(max(S) + 1))</p>
-   <p>Next create a tree of height H where all non-leaf nodes have 8 children. Each node in the tree has
-a single byte value. Given a node <i>p</i> which has 8 children: <i>c<sub>0</sub></i> ... <i>c<sub>7</sub></i> and is in a tree, <i>T</i>, of height <i>H</i>, then:</p>
+an tree where each node has a fixed number of children that recursively sub-divides an interval into
+equal partitions. A tree of height <i>H</i> with branching factor <i>B</i> can store set membership
+for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree is encoded into
+a ByteString for transport.</p>
+   <p>To construct the tree <i>T</i> which encodes set <i>S</i> first select the branching factor <i>B</i> (how many children each node has). <i>B</i> can be 4, 8, 16, or 32.</p>
+   <p class="note" role="note"><span>Note:</span> the encoder is free to use any of the possible branching factors, but should try to pick one
+that will give this smallest encoding. It’s likely that a heuristic based on the set size and/or
+maximum value will generally select a good branching factor. Alternatively, the encoder could test
+encoding with the various branching factors and keep the encoding which is the smallest.</p>
+   <p>Next, determine the height, <i>H</i>, of the tree:</p>
+   <p><i>H</i> = ceil(log<sub><i>B</i></sub>(max(S) + 1))</p>
+   <p>Next create a tree of height H where all non-leaf nodes have <i>B</i> children. Each node in the tree
+has a single value composed of <i>B</i> bits. Given a node <i>p</i> which has <i>B</i> children: <i>c<sub>0</sub></i> ... <i>c<sub><i>B</i> - 1</sub></i> and is in a tree, <i>T</i>, of height <i>H</i>, then:</p>
    <ul>
     <li data-md>
      <p>D(<i>c<sub>i</sub></i>) is depth of node <i>c<sub>i</sub></i>, that is the number of edges between
 the root node and <i>c<sub>i</sub></i>.</p>
     <li data-md>
      <p>Start(<i>c<sub>i</sub></i>) is the start (inclusive) of the interval  covered by <i>c<sub>i</sub></i> :<br> Start(<i>c<sub>i</sub></i>) =
- Start(<i>p</i>) + <i>i</i> * 8<sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup></p>
+ Start(<i>p</i>) + <i>i</i> * <i>B</i><sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup></p>
     <li data-md>
      <p>End(<i>c<sub>i</sub></i>) is the end (exclusive) of the interval  covered by <i>c<sub>i</sub></i> :<br> End(<i>c<sub>i</sub></i>) =
- Start(<i>p</i>) + (<i>i</i> + 1) * 8<sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup></p>
+ Start(<i>p</i>) + (<i>i</i> + 1) * <i>B</i><sup><i>H</i> - D(<i>c<sub>i</sub></i>)</sup></p>
     <li data-md>
      <p>Start(root node) = 0</p>
     <li data-md>
-     <p>The value of node <i>p</i> is as a single byte (8 bits). If its bits are numbered from 0
-(least significant bit) to 7 (most significant bit) then bit <i>i</i> will be 1 if the
+     <p>The value of node <i>p</i> is composted of <i>B</i> bits. If its bits are numbered from 0
+(least significant bit) to <i>B</i> - 1 (most significant bit) then bit <i>i</i> will be 1 if the
 set <i>S</i> contains at least one member in the interval
 [Start(<i>c<sub>i</sub></i>), End(<i>c<sub>i</sub></i>)), otherwise bit <i>i</i> will be 0.</p>
     <li data-md>
      <p>If for node <i>p</i>, End(<i>p</i>) - Start(<i>p</i>) = 1, then <i>p</i> will have no children
-and its value byte is 0.</p>
+and its value is 0.</p>
    </ul>
    <p>Finally, tree <i>T</i> is encoded into a ByteString by traversing the nodes of the <i>T</i> in level
-order and appending the value byte for each node to the ByteString if the value byte has a non-zero
+order and appending the value for each node to the ByteString if the value has a non-zero
 value.</p>
-   <div class="example" id="example-ca8126f0">
-    <a class="self-link" href="#example-ca8126f0"></a> The set {2, 33, 323} is encoded as the byte string: 
+   <p>TODO(garretrieger): add info on the first byte which encodes BF and depth.
+TODO(garretrieger): add info on replacing a fully filled sub-tree with a 0 value.</p>
+   <div class="example" id="example-a03bf883">
+    <a class="self-link" href="#example-a03bf883"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the byte string: 
 <pre>  |- level 0 -|------ level 1 --------|----------- level 2 ----------------|
   |     n0    |     n1          n2    |      n3         n4          n5     |
   [ 0b00100001, 0b00010001, 0b00000001, 0b00000100, 0b00000010, 0b00001000 ]
@@ -623,6 +630,11 @@ value.</p>
      <li data-md>
       <p>0b00001000 is child 0 of n<sub>2</sub>, bit 3 is set for the interval [323, 324) or 323.</p>
     </ul>
+   </div>
+   <div class="example" id="example-b3fa4470">
+    <a class="self-link" href="#example-b3fa4470"></a> The set {2, 33, 323} in a tree with a branching factor of 4 is encoded as the byte string: 
+<pre>  TODO(garretrieger): update this example for BF4.
+</pre>
    </div>
    <h4 class="heading settled" data-level="2.1.4" id="objects"><span class="secno">2.1.4. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
    <p>Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version b94c7e755, updated Fri Feb 19 16:28:59 2021 -0800" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="ea3b40b12d03ba801f341310680329b95822a917" name="document-revision">
+  <meta content="5e92d9e4368fadd3075f2d6d5009ad682423f31e" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -561,12 +561,12 @@ should be encoded by CBOR are given in the definition of those data types.</p>
    </table>
    <h4 class="heading settled" data-level="2.1.3" id="sparsebitset"><span class="secno">2.1.3. </span><span class="content">SparseBitSet</span><a class="self-link" href="#sparsebitset"></a></h4>
    <p>A data structure which compactly stores a set of distinct unsigned integers. The set is represented as
-an tree where each node has a fixed number of children that recursively sub-divides an interval into
+a tree where each node has a fixed number of children that recursively sub-divides an interval into
 equal partitions. A tree of height <i>H</i> with branching factor <i>B</i> can store set membership
 for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree is encoded into
 a ByteString for transport.</p>
    <p>To construct the tree <i>T</i> which encodes set <i>S</i> first select the branching factor <i>B</i> (how many children each node has). <i>B</i> can be 4, 8, 16, or 32.</p>
-   <p class="note" role="note"><span>Note:</span> that while the encoder can use any of the possible branching factors, but it is recommended to
+   <p class="note" role="note"><span>Note:</span> the encoder can use any of the possible branching factors, but it is recommended to
 use 4 as that has been shown to give the smallest encodings for most sets typically encountered.</p>
    <p>Next, determine the height, <i>H</i>, of the tree:</p>
    <p><i>H</i> = ceil(log<sub><i>B</i></sub>(max(S) + 1))</p>
@@ -595,7 +595,7 @@ children.</p>
    <p>The tree is encoded into a bit string. The bits of the bit string are numbered from 0 to M. When
 appending multi bit values to the bit string, bits are added in order from least significant bit to
 most significant bit.</p>
-   <p>To encode tree <i>T</i> into a bit string first append 2 bits which encode the branching factor:</p>
+   <p>First append 2 bits which encode the branching factor:</p>
    <table>
     <tbody>
      <tr>
@@ -616,11 +616,12 @@ most significant bit.</p>
    </table>
    <p>Then append the value <i>H</i> - 1 as a 6 bit unsigned integer.</p>
    <p>Next the nodes are encoded into the bit string by traversing the nodes of the <i>T</i> in level
-order and appending the value for each node to the bit string. If all set values covered by a node’s
-interval are present within set <i>S</i> that node can instead be encoded in the ByteString as <i>B</i> bits all set to zero. Additionally all children of that node must not be encoded.</p>
-   <p>Lastly the bit string is converted into a ByteString by converting each subsequent group of 8 bits
-into a byte. The lower bit index is the least significant bit and the highest bit index is the
-most significant bit.</p>
+order and appending the value for each non-zero node to the bit string.If all set values
+covered by a node’s interval are present within set <i>S</i> that node can instead be encoded in the
+bit string as <i>B</i> bits all set to zero. All children of that node must not be encoded.</p>
+   <p>Lastly the bit string is converted into a ByteString by converting each consecutive group of 8 bits
+into the next byte of the string. The bit with the smallest index in the bit string is the least
+significant bit in the byte and the bit with the largest index is the most significant bit.</p>
    <div class="example" id="example-76606ecb">
     <a class="self-link" href="#example-76606ecb"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the bit string: 
 <pre>  BitString:


### PR DESCRIPTION
- Generalizes the structure so it can use branch factors other than the previously hardcoded 8. Using 4 is recommended for the general case, but I left open the option for encoders to chose factors other than 4.
- Added interval encoding using a 0 value node. My current thinking is that this does not add any additional size to the encoding even if it's not used if we recommend that the encoder should encode intervals inside of CompressedSet. So we should at least include it in the spec so that an advanced encoder could make use of it if desired.
- Adds an example that covers a branch factor of 4, with an encoded interval.