### PR TITLE
Simplifies the client specification and adds server specification for patch subset

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -449,6 +449,8 @@ should interpret and process the fields of the object as follows:
     resend the request that triggered this response but use the new codepoint ordering provided in
     this response.
 
+TODO(garretrieger): how to handle error status codes (ie. 4xx, 5xx).
+
 ### Client Side Checksum Mismatch ### {#client-side-checksum-mismatch}
 
 If the the checksum of the font subset computed by the client does not match the
@@ -463,6 +465,38 @@ If the the checksum of the font subset computed by the client does not match the
 
 Server {#server}
 ----------------
+
+### Responding to PatchRequest's ### {#handling-patch-request}
+
+If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> that
+was populated according to the requirements in [[#extend-subset]] then it should respond with HTTP
+status code 200. The body of the response should be a single
+<a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.
+
+TODO(garretrieger): describe producing two codepoint sets - codepoints needed, codepoints have
+TODO(garretrieger): say something about original font checksum? it doesn't need to match...
+TODO(garretrieger): note the server should try and produce a patch instead of a replacement
+                    where possible.         
+
+The response object must:
+
+*  when processed by the client according to [[#handling-patch-response]] result in a font subset
+    that contains data for at least the union of the set of codepoints needed and the sets of
+    codepoints the client already has. The format of the used patch in the response must be one of
+    those listed in <code>accept_patch_format</code>.
+
+* OR, ... TODO(garretrieger): alternately can respond just with an updated codepoint ordering.
+
+
+The fields should
+be set as follows
+
+### PatchResponse ### {#patch-response}
+
+### Error Responses ###
+
+
+///////////////// OLD
 
 ### Handling Requests ### {#handling-requests}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -374,7 +374,7 @@ If sent as a GET request the client will include a single query parameter:
 
 ### Standard Response ### {#rebase-standard-response}
 
-The server will response to a new font request with a <a href="#rebase-response">New Font Response</a>.
+The server will respond to a new font request with a <a href="#rebase-response">New Font Response</a>.
 
 ### Errors ### {#rebase-errors}
 
@@ -433,7 +433,7 @@ If the server has not previously provided a <code>codepoint_ordering</code> for 
 
 ### Standard Response ### {#patch-standard-response}
 
-The server will response to a new font request with a
+The server will respond to a new font request with a
 <a href="#patch-response">Patch Font Response</a>.
 
 ### Recoverable Errors ### {#patch-recoverable-errors}
@@ -486,6 +486,14 @@ If a reordering mismatch is detected it must be resolved prior to attempting to 
 the other recoverable error scenarios.
 
 #### Client Side Patched Base Checksum Mismatch #### {#patch-mismatch}
+
+TODO(garretrieger): this belongs with info about client handling of the response
+
+After a client receives a [[#patch-response]] and computes a new version of the font the client must
+compare the checksum [[#computing-checksums]] of the new font to
+<a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
+client must discard the response and should resend the request as a [[#rebase-request]]. Upon receiving
+a new copy of the font the client can replace any existing data it has for that font.
 
 #### Cmap Format 4 Overflow #### {#cmap4-overflow}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -466,238 +466,50 @@ If the the checksum of the font subset computed by the client does not match the
 Server {#server}
 ----------------
 
-### Responding to PatchRequest's ### {#handling-patch-request}
+### Responding to a PatchRequest ### {#handling-patch-request}
+
+TODO(garretrieger): url identifies the font being operated on ('the requested font')
+TODO(garretrieger): https only.
+TODO(garretrieger): Identify at least one patch format which all client/servers must support.
 
 If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> that
 was populated according to the requirements in [[#extend-subset]] then it should respond with HTTP
 status code 200. The body of the response should be a single
 <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.
 
-TODO(garretrieger): describe producing two codepoint sets - codepoints needed, codepoints have
-TODO(garretrieger): say something about original font checksum? it doesn't need to match...
-TODO(garretrieger): note the server should try and produce a patch instead of a replacement
-                    where possible.         
-
-The response object must:
-
-*  when processed by the client according to [[#handling-patch-response]] result in a font subset
-    that contains data for at least the union of the set of codepoints needed and the sets of
-    codepoints the client already has. The format of the used patch in the response must be one of
-    those listed in <code>accept_patch_format</code>.
-
-* OR, ... TODO(garretrieger): alternately can respond just with an updated codepoint ordering.
-
-
-The fields should
-be set as follows
-
-### PatchResponse ### {#patch-response}
-
-### Error Responses ###
-
-
-///////////////// OLD
-
-### Handling Requests ### {#handling-requests}
-
-TODO(garretrieger):
-- url identifies the font being operated on ('the requested font')
-- where to find the message.
-- CBOR decoding
-- Accepted http methods.
-- Identify at least one patch format which all client/servers must support.
-
-### Handling New Font Request ### {#handling-rebase-request}
-
-If a request is received where:
-
-* <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> is a non-empty set,
-* <a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a> is not set or is an empty set,
-* and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is not set or is an empty set;
-
-then the server must:
-
-1. Generate a subset of the requested font that contains at least the code points
-    in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.
-
-2. Encode the subset with one of the formats listed in
-    <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.
-
-3. Respond with a [[#rebase-response]].
-
-### Handling Patch Font Request ### {#handling-patch-request}
-
-If a request is received where:
-
-*  At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>
-    and <a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a> is a non-empty set.
-
-*  At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a>
-    and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is a non-empty set.
-
-then the server must:
-
-1.  Determine the codepoint reordering of the requested font. See [[#codepoint-reordering]].
-
-2.  Compute the codepoint [[#reordering-checksum]] of the reordering generated in step 1.
-     If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a>
-     this is a recoverable error, follow the procedure in [[#codepoint-reordering-mismatch]].
-
-3.  Compute the checksum of the requested font. If it is not equal to
-     <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a>
-     this is a recoverable error, follow the procedure in [[#client-font-mismatch]].
-
-3.  Transform the indices_have and indices_needed sets into codepoints by applying the codepoint
-     reordering from step 1.
-   
-4.  Union the transformed indices_have and codepoints_have sets to form the base codepoint set.
-
-5.  Union the transformed indices_needed, codepoints_needed, and  base set to form the extended
-     codepoint set.
-
-6.  Generate:
-     *  The base font subset, by subsetting the requested font to exactly thecodepoints in the base
-         set.
-     *  The extended font subset, by subsetting the requested font to at least the codepoints in the
-         extended set.
-
-7.  Compute the checksum of the base font subset. If it is not equal to
-     <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> this is a recoverable
-     error, follow the procedure in [[#client-base-mismatch]].
-
-8.  Generate a binary difference between the extended font subset and the base font subset using
-     one of the patch formats listed in
-     <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.
-
-9. Respond with a [[#patch-response]].
-
-### Client Codepoint Reordering does not Match Servers ### {#codepoint-reordering-mismatch}
-
-TODO(garretrieger): case where codepoint reodering differs because of a upgraded original font.
-
-The codepoint mapping used by the client may not be recognized by the server. This case can be
-detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
-checksum of the server’s codepoint reordering. In some cases the mismatch is caused by the server
-having updated the requested font with a new version which in turn can change the reordering.
-If the server still has access 
-
-*  If the codepoint ordering has changed because the requested font has been updated with a newer
-     version and the server still has the previous
-
-
-
-If there is a mismatch the server should respond with
-a [[#reindex-response]]. After receiving a [[#reindex-response]] the client should resend their
-#patch-request (TODO) using the new code point reordering.
-
-If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
-the other recoverable error scenarios.
-
-
-### Client’s Original Font does not Match Server’s ### {#client-font-mismatch}
-
-Over time servers may upgrade the original copies of a font with newer
-versions. After such an upgrade, clients who have subsets built from the
-previous versions may contact the server and request a patch against the
-previous version of the font.
-
-The server can detect this case by checking that
-<a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> matches the checksum of
-the current version of the font. If a mismatch is detected there are two possible resolutions:
-
-*  Patch client to the new font. This is possible if the server has access to the font files for
-    previous versions of the font, and the provided checksum matches a previous version. Follow
-    the remaining steps in [[#handling-patch-request]] but replace the font used to generate
-    the base subset with the previous version that has a checksum matching
-    <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>.
-   
-*  Replace the clients copy of the font. If the server is unable to match the provided checksum to any
-    version of the font it has, then a [[#rebase-response]] should be sent instead which will instruct
-    the client to replace the version they have with the newer version. The replacement font must cover
-    at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and
-    <code>codepoints_needed/indices_needed</code> fields.
-
-### Client’s Base does not Match Server’s ### {#client-base-mismatch}
-
-Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
-the base font that a server computes not matching the base font that a client has. This case can be
-detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a>
-to the checksum for the base that the server computed. If there is a mismatch the server should respond
-with a [[#rebase-response]] instead of the usual [[#patch-response]]. The replacement font must cover
-at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and
-<code>codepoints_needed/indices_needed</code> fields.
-
-
-### Subsetting Failures ### {#subsetting-failures}
-
-### New Font Response ### {#rebase-response}
-
-TODO(garretrieger): update wording here to match new organization.
-
-If the client asks for a new font the server will respond with a single
-<a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via COBR:
-
-*  <a href="#PatchResponse"><code>PatchResponse.response_type</code></a>:<br/>
-    is set to REBASE.
-   
-*  <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>:<br/>
-    The checksum ([[#computing-checksums]]) computed for the full unmodified original font.
-
-*  <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>:<br/>
-    The compression format used to encode
-    <a href="#PatchResponse"><code>PatchResponse.patch</code></a>.
-    TODO(garretrieger): needs to be one of the formats specified by the client.
-   
-*  <a href="#PatchResponse"><code>PatchResponse.patch</code></a>:<br/>
-    A subset of the original font that contains data for at least the codepoints requested by the
-    client in the <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> field. The
-    server may opt to expand the subset requested by the client to include additional characters that
-    may be needed for future content. The font subset is compressed by the format specified in
-    <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>.
-  
-*  <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a>:<br/>
-    The checksum ([[#computing-checksums]]) computed for the subsetted font,
-    prior to compression.
-    
-*  <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>:<br/>
-    The server should provide a codepoint reordering which the client will use to
-    communicate codepoint sets back to the server. See [[#codepoint-reordering]] for details. The
-    server is free to chose the mapping, but the mapping must use only code points in
-    the original font and must map all codepoints in the original font.
-   
-*  <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a>:<br/>
-     Checksum for the codepoint ordering [[#reordering-checksum]].
-
-If the client receives a new font response it should replace any version of the font it currently has
-with the decompressed contents of the <a href="#PatchResponse"><code>PatchResponse.patch</code></a>
-Also <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>, 
-<a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>, and
-<a href="#PatchResponse"><code>PatchResponse.codepoint_ordering_checksum</code></a> should be saved as
-they are needed for future requests.
-
-### Patch Font Response ### {#patch-response}
-
-TODO(garretrieger): write this.
-
-### Update Codepoint Ordering Response ###  {#reindex-response}
-
-TODO(garretrieger): write this.
-
-### Error Response ### {#error-response}
-
-TODO(garretrieger): write this.
-
-#### Font Not Found #### {#error-font-not-found}
-
-TODO(garretrieger): write this.
-
-#### Bad Request #### {#error-bad-request}
-
-TODO(garretrieger): write this.
-
-#### Internal Error #### {#error-internal-error}
-
-TODO(garretrieger): write this.
+From the request object the server can produce two codepoint sets:
+
+1.  Codepoints the client has: formed by the union of the codepoint sets specified by
+     <code>codepoints_have</code> and <code>indices_have</code>. The indices in
+     <code>indices_have</code> must be mapped to codepoints by the application of the
+     codepoint reordering with a checksum matching <code>ordering_checksum</code>.
+
+2.  Codepoints the client needs: formed by the union of the codepoint sets specified by
+     <code>codepoints_needed</code> and <code>indices_needed</code>. The indices in
+     <code>indices_have</code> must be mapped to codepoints by the application of the
+     codepoint reordering with a checksum matching <code>ordering_checksum</code>.
+
+If the server does not recognize the codepoint ordering used by the client, it must respond
+with a response that will cause the client to update it's codepoint ordering to one the server
+will recognize via the process described in [[#handling-patch-response]] and not include any patch.
+That is the <code>patch</code> and <code>replacement</code> fields must not be set.
+
+Otherwise when the response is applied by the client following the process in [[#handling-patch-response]]
+to a font subset with checksum <code>base_checksum</code> it must result in an extended font subset that contains
+data for at least the union of the set of codepoints needed and the sets of codepoints the client already
+has. The format of patch in the either the <code>patch</code> or <code>replace</code> field must be one of
+those listed in <code>accept_patch_format</code>.
+
+Note: the server can respond with either a patch or a replacement but should try to produce a patch where possible.
+      replacement's should only be used in situations where the server is unable to recreate the clients state
+      in order to generate a patch against it.
+
+Possible error responses:
+
+*  If the request is malformed the server may instead respond with http status code 400 to indicate an error.
+
+*  If the requested font is not recognized by the server it may respond with http status code 404 to indicate
+    a not found error.
 
 Procedures {#procedures}
 ------------------------

--- a/Overview.bs
+++ b/Overview.bs
@@ -308,40 +308,47 @@ The list of ranges is encoded as a series of deltas. For example the ranges
 <table>
   <tr><th>ID</th><th>Field Name</th><th>Value Type</th></tr>
   <tr><td>0</td><td>protocol_version</td><td>Integer</td></tr>
-  <tr><td>1</td><td>original_font_checksum</td><td>Integer</td></tr>
-  <tr><td>2</td><td>base_checksum</td><td>Integer</td></tr>
-  <tr><td>3</td><td>patch_format</td><td>ArrayOf&lt;Integer&gt;</td></tr>
-  <tr><td>4</td><td>codepoints_have</td><td>CompressedSet</td></tr>
-  <tr><td>5</td><td>codepoints_needed</td><td>CompressedSet</td></tr>
+  <tr><td>1</td><td>accept_patch_format</td><td>ArrayOf&lt;Integer&gt;</td></tr>
+  <tr><td>2</td><td>codepoints_have</td><td>CompressedSet</td></tr>
+  <tr><td>3</td><td>codepoints_needed</td><td>CompressedSet</td></tr>
+  <tr><td>4</td><td>indices_have</td><td>CompressedSet</td></tr>
+  <tr><td>5</td><td>indices_needed</td><td>CompressedSet</td></tr>
   <tr><td>6</td><td>ordering_checksum</td><td>Integer</td></tr>
-  <tr><td>7</td><td>indices_have</td><td>CompressedSet</td></tr>
-  <tr><td>8</td><td>indices_needed</td><td>CompressedSet</td></tr>
+  <tr><td>7</td><td>original_font_checksum</td><td>Integer</td></tr>
+  <tr><td>8</td><td>base_checksum</td><td>Integer</td></tr>
 </table>
 
-patch_format can include be any of the values specified in [[#patch-formats]].
+For a PatchRequest object to be well formed:
+
+*  <code>protocol_version</code> must be set to 0.
+*  <code>accept_patch_format</code> can include any of the values listed in [[#patch-formats]].
+*  If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
+    then <code>ordering_checksum</code> must be set.
+*  If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then
+    <code>original_font_checksum</code> and <code>base_checksum</code> must be set.
 
 #### PatchResponse #### {#PatchResponse}
 
 <table>
   <tr><th>ID</th><th>Field Name</th><th>Value Type</th></tr>
-  <tr><td>0</td><td>response_type</td><td>Integer</td></tr>
-  <tr><td>1</td><td>original_font_checksum</td><td>Integer</td></tr>
-  <tr><td>2</td><td>patch_format</td><td>Integer</td></tr>  
-  <tr><td>3</td><td>patch</td><td>ByteString</td></tr>  
-  <tr><td>4</td><td>patched_checksum</td><td>Integer</td></tr>  
-  <tr><td>4</td><td>codepoint_ordering</td><td>CompressedList</td></tr>  
-  <tr><td>5</td><td>ordering_checksum</td><td>Integer</td></tr>  
+
+  <tr><td>0</td><td>patch_format</td><td>Integer</td></tr>  
+  <tr><td>1</td><td>patch</td><td>ByteString</td></tr>
+  <tr><td>2</td><td>replacement</td><td>ByteString</td></tr>  
+
+  <tr><td>3</td><td>original_font_checksum</td><td>Integer</td></tr>
+  <tr><td>4</td><td>patched_checksum</td><td>Integer</td></tr>
+  
+  <tr><td>5</td><td>codepoint_ordering</td><td>CompressedList</td></tr>  
+  <tr><td>6</td><td>ordering_checksum</td><td>Integer</td></tr>  
 </table>
 
-response_type can be one of the following values:
-
-<table>
-  <tr><th>Value</th><th>Response Type</th></tr>
-  <tr><td>0</td><td>PATCH</td>
-  <tr><td>1</td><td>REBASE</td>
-  <tr><td>2</td><td>REINDEX</td>
-</table>
-
+For a PatchRequest object to be well formed:
+*  <code>patch_format</code> can be any of the values listed [[#patch-formats]]
+*  Only one of <code>patch</code> and <code>replacement</code> may be set.
+*  If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>,
+     <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.
+*  If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.
 
 Client {#client}
 ----------------
@@ -351,9 +358,8 @@ Client {#client}
 The client will need to maintain at minimum the following state for each font file being incrementally
 transferred:
 
-
-*  Font subset: the binary data for the most recent version of the subset of the font being
-    incrementally transferred.
+*  Font subset: a byte array containing the binary data for the most recent version of the subset of
+    the font being incrementally transferred. For a new font this is initialized to empty byte array.
 *  Original font checksum: the most recent value of
     <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
     from the server for this font.
@@ -363,157 +369,96 @@ transferred:
     <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a>
     for this font.
 
-### New Font Request ### {#rebase-request}
-
-A new font request is sent by the client to begin incrementally transferring a font. The request
-specifies a set of codepoints that the client needs to render with the font and in return the server
-will provide a copy of the font that supports at least those codepoints. A new font request is made
-via HTTP and may use either the GET or POST method.
+### Extending the Font Subset ### {#extend-subset}
 
 TODO(garretrieger): mention how the url identifies the specific font being requested.
 
-#### POST #### {#rebase-request-post}
+A client extends its font subset to cover additional codepoints by making HTTP requests to
+a Patch Subset server. The HTTP request must use either the GET or POST method:
 
-If sent as a POST request the post body will be a single
-<a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. All fields of
-<a href="#PatchRequest"><code>PatchRequest</code></a> should be left unset except for:
+*  If sent as a POST request the post body will be a single
+    <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.
 
-*  <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>:<br/>
-    This field is be populated with the <a href="#CompressedSet">set</a> of
-    unicode codepoints which the client requires data for.
+*  If sent as a GET request the client will include a single query parameter,
+    <code>request</code>:<br/> the value is a single
+    <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then base64url
+    encoding [[rfc4648]].
+
+The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
+as follows:
+
+*  <code>protocol_version</code>: set to 0.
+
+*  <code>accept_patch_format</code>: set to the list of [[#patch-formats]] that this client is
+    capable of decoding. Must contain at least one format.
+
+*  <code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
+    contains data for. If the current font subset is an empty byte array this field is left unset.
+    If the client has a codepoint ordering for this font then this field should not be set.
+
+*  <code>codepoints_needed</code>: set to the set of codepoints that the client wants to
+    add to its font subset. If the client has a codepoint ordering for this font then this
+    field should not be set.
+
+*  <code>indices_have</code>: encodes the set of codepoints that the current
+    font subset contains data for. The codepoint values are transformed to indices by applying
+    [[#codepoint-reordering]] to each codepoint value. If the client does not have a codepoint
+    ordering for this font then this field should not be set.
+
+*  <code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
+    font subset. The codepoint values are transformed to indices by applying
+    [[#codepoint-reordering]] to each codepoint value. If the client does not have a codepoint
+    ordering for this font then this field should not be set.
+
+*  <code>ordering_checksum</code>: If either of <code>indices_have</code> or
+    <code>indices_needed</code> is set then this must be set to the current value of
+    <code>ordering_checksum</code> saved in the state for this font.
+
+*  <code>original_font_checksum</code>:
+    Set to saved value for <code>original_font_checksum</code> in the state for this font. If
+    there is no saved value leave this field unset.
    
-*  <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>:<br/>
-    This field should be populated with the set of <a href="#patch-formats">patch formats</a> that this
-    client is capable of decoding. At least one format must be provided.
+*  <code>base_checksum</code>:
+    Set to the checksum of the font subset byte array saved in the state for this font. See:
+    [[#computing-checksums]].
 
-#### GET #### {#rebase-request-get}
+### Handling PatchResponse ### {#handling-patch-response}
 
-If sent as a GET request the client will include a single query parameter:
+If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a>
+if will respond with HTTP status code 200 and the body of the response will be a
+<a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
+should interpret and process the fields of the object as follows:
 
-*  <code>request</code>:<br/>
-    The value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR
-    and then base64url encoding [[rfc4648]]. The <a href="#PatchRequest"><code>PatchRequest</code></a>
-    object uses the same fields as specified for a <a href="#rebase-request-post">POST</a> request.
+1.  If field <code>replacement</code> is set then: the byte array in this field is a binary patch
+     in the format specified by <code>patch_format</code>. Apply the binary patch to a base which
+     is a empty byte array. Replace the saved font subset with the result of the patch application.
 
-### Patch Font Request ### {#patch-request}
+2. If field <code>patch</code> is set then:  the byte array in this field is a binary patch
+    in the format specified by <code>patch_format</code>. Apply the binary patch to the saved font
+    subset. Replace the saved font subset with the result of the patch application.
 
-A patch font request is sent by a client to add data for additional codepoints to its font. Patch font
-requests are sent via HTTP and can only use the POST method. The request body is a single
-<a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. The fields of
-should be set as follows:
+3. If either <code>replacement</code> or <code>patch</code> is set then:
+    <a href="#computing-checksums">compute the checksum</a> of the font subset produced by the patch
+    application in steps 1 or 2. If the computed checksum is not equal to <code>patched_checksum</code>
+    this is a recoverable error. Follow the procedure in [[#client-side-checksum-mismatch]]. Otherwise
+    update the saved original font checksum with the value in <code>original_font_checksum</code>.
 
-*  <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>:<br/>
-    Set to the last saved value of original_font_checksum provided by a
-    previous response from the server for this particular font.
-   
-*  <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a>:<br/>
-    Set to the checksum [[#computing-checksums]] of the client’s most recent
-    copy of the font.
-   
-*  <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>:<br/>
-    This field should be populated with the set of <a href="#patch-formats">patch formats</a> that this
-    client is capable of decoding. At least one format must be provided.
-
-If the server has previously provided a <code>codepoint_ordering</code> for this
-font the client should set:
-
-*  <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a>:<br/>
-    Set to the most recent value of <code>ordering_checksum</code> provided by a
-    response from the server for this particular font.
-   
-*  <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a>:<br/>
-    Encodes the set of codepoints that are covered by the client’s current copy of the font.
-    The codepoint values are transformed to indices by applying <code>codepoint ordering</code>
-    [[#codepoint-reordering]] to each codepoint value.
-   
-*  <a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a>:<br/>
-    Encodes the set of codepoints that the clients would like added to it’s copy of the font.
-    The codepoint values are transformed to indices by applying <code>codepoint ordering</code>
-    [[#codepoint-reordering]] to each codepoint value.
-
-If the server has not previously provided a <code>codepoint_ordering</code> for this font then the
-<code>codepoints_have</code> and <code>codepoints_needed</code> fields should be used instead:
-
-*  <a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a>:<br/>
-    The set of codepoints that are covered by the client’s copy of the font.
-   
-* <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>:<br/>
-    The set of codepoints that the clients would like added to it’s copy of
-    the font.
-
-### Handling New Font Response ### {#handling-rebase-response}
-
-If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a>
-is equal to REBASE, then the client must:
-
-1.  Decode the contents of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> using
-     the decoder specified in <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>
-     
-2. Compute a checksum ([[#computing-checksums]]) of the decoded value of
-    <a href="#PatchResponse"><code>PatchResponse.patch</code></a>
-
-3. Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
-    the computed checksum in step 2. If they do not match this is an unrecoverable error. Do not
-    proceed to step 4.
-
-4. Replace the saved state for this font or create new saved state if none yet exists:
-    The decoded value of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> is the font
-    subset, <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
-    original font checksum, and
-    <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
-    codepoint reordering map.
-
-### Handling Patch Font Response ### {#handling-patch-response}
-
-If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a>
-is equal to PATCH, then the client must:
-
-1.  Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>
-     matches the original font checksum stored in the clients state. If they do not match
-     this is a recoverable error, follow the procedure in [[#client-side-checksum-mismatch]].
-
-2.  Apply the decoded patch to the client's font subset. The format of the patch is specified
-     by the <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a> field. This
-     produces a extended font subset. Replace the previous font subset stored in the client's
-     state with this the new one.
-
-3.  Compute the checksum ([[#computing-checksums]]) of the extended font subset.
-
-4.  Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
-     the computed checksum in step 3. If they do not match this is a recoverable error, follow
-     the procedure in [[#client-side-checksum-mismatch]].
-
-5.  If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and
-     <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
-     then replace the codepoint ordering and checksum saved in the clients state with the new one
-     specified in the response.
-     
-
-### Handling Update Codepoint Ordering Response ### {#handling-reindex-response}
-
-If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a>
-is equal to REINDEX, then the client must:
-
-1.  Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>
-     matches the original font checksum stored in the clients state. If they do not match
-     this is a recoverable error, follow the procedure in [[#client-side-checksum-mismatch]].
-
-2.  If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and
-     <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
-     then replace the codepoint ordering and checksum saved in the clients state with the new one
-     specified in the response.
-
-3.  Resend the request which triggered this response using the new codepoint ordering.
-
+4. If fields <code>codepoint_ordering</code> and <code>ordering_checksum</code> are set then update
+    the saved codepoint ordering and checksum with the new values specified by these two fields.
+    If neither <code>replacement</code> or <code>patch</code> are set, then the client should
+    resend the request that triggered this response but use the new codepoint ordering provided in
+    this response.
 
 ### Client Side Checksum Mismatch ### {#client-side-checksum-mismatch}
 
-If either the clients saved original font checksum or the checksum of the patched font subset
-do not match the checksums provided in a response from the server then the client should:
+If the the checksum of the font subset computed by the client does not match the
+<code>patched_checksum</code> in the server's response then the client should:
 
 1. Discard all currently saved state for this font.
 
-2. Resend the request as a [[#rebase-request]] with the codepoints that are currently needed.
+2. <a href="#extend-subset">Resend the request</a>. Set the <code>codepoints_needed</code> field
+    to the union of the codepoints in the discarded font subset and the set of code points
+    the the previous request was trying to add.
 
 
 Server {#server}
@@ -609,7 +554,7 @@ If the server still has access
 
 If there is a mismatch the server should respond with
 a [[#reindex-response]]. After receiving a [[#reindex-response]] the client should resend their
-[[#patch-request]] using the new code point reordering.
+#patch-request (TODO) using the new code point reordering.
 
 If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.

--- a/Overview.bs
+++ b/Overview.bs
@@ -353,9 +353,12 @@ transferred:
 *  Font subset: the binary data for the most recent version of the subset of the font being
     incrementally transferred.
 *  Original font checksum: the most recent value of
-    <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> received
+    <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
     from the server for this font.
 *  Codepoint Reordering Map: The most recent [[#codepoint-reordering]] received from the server
+    for this font.
+*  Codepoint Reordering Checksum: The most recent
+    <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a>
     for this font.
 
 ### New Font Request ### {#rebase-request}
@@ -486,7 +489,20 @@ is equal to PATCH, then the client must:
 
 ### Handling Update Codepoint Ordering Response ### {#handling-reindex-response}
 
-TODO(garretrieger): write this.
+If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a>
+is equal to REINDEX, then the client must:
+
+1.  Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>
+     matches the original font checksum stored in the clients state. If they do not match
+     this is a recoverable error, follow the procedure in [[#client-side-checksum-mismatch]].
+
+2.  If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and
+     <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
+     then replace the codepoint ordering and checksum saved in the clients state with the new one
+     specified in the response.
+
+3.  Resend the request which triggered this response using the new codepoint ordering.
+
 
 ### Client Side Checksum Mismatch ### {#client-side-checksum-mismatch}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -438,7 +438,8 @@ If the server has not previously provided a <code>codepoint_ordering</code> for 
 
 ### Handling New Font Response ### {#handling-rebase-response}
 
-If in response to a request made for a font a client receives a [[#rebase-response]] it must:
+If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a>
+is equal to REBASE, then the client must:
 
 1.  Decode the contents of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> using
      the decoder specified in <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>
@@ -459,25 +460,48 @@ If in response to a request made for a font a client receives a [[#rebase-respon
 
 ### Handling Patch Font Response ### {#handling-patch-response}
 
-TODO(garretrieger): write this.
+If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a>
+is equal to PATCH, then the client must:
 
-#### Client Side Patched Base Checksum Mismatch #### {#patch-mismatch}
+1.  Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>
+     matches the original font checksum stored in the clients state. If they do not match
+     this is a recoverable error, follow the procedure in [[#client-side-checksum-mismatch]].
 
-After a client receives a [[#patch-response]] and computes a new version of the font the client must
-compare the checksum [[#computing-checksums]] of the new font to
-<a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
-client must discard the response and should resend the request as a [[#rebase-request]]. Upon receiving
-a new copy of the font the client can replace any existing data it has for that font.
+2.  Apply the decoded patch to the client's font subset. The format of the patch is specified
+     by the <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a> field. This
+     produces a extended font subset. Replace the previous font subset stored in the client's
+     state with this the new one.
 
+3.  Compute the checksum ([[#computing-checksums]]) of the extended font subset.
+
+4.  Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
+     the computed checksum in step 3. If they do not match this is a recoverable error, follow
+     the procedure in [[#client-side-checksum-mismatch]].
+
+5.  If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and
+     <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
+     then replace the codepoint ordering and checksum saved in the clients state with the new one
+     specified in the response.
+     
 
 ### Handling Update Codepoint Ordering Response ### {#handling-reindex-response}
 
 TODO(garretrieger): write this.
 
-TODO reorganize sections below here
+### Client Side Checksum Mismatch ### {#client-side-checksum-mismatch}
+
+If either the clients saved original font checksum or the checksum of the patched font subset
+do not match the checksums provided in a response from the server then the client should:
+
+1. Discard all currently saved state for this font.
+
+2. Resend the request as a [[#rebase-request]] with the codepoints that are currently needed.
+
 
 Server {#server}
 ----------------
+
+TODO reorganize sections below here
 
 ### Handling New Font Request ### {#handling-rebase-request}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -44,10 +44,25 @@ Introduction {#intro}
 Patch Based Incremental Transfer {#patch-incxfer}
 =================================================
 
-TODO(garretrieger): Describe the high level version of how this version operates.
+Overview {#patch-overview}
+--------------------------
 
-TODO(garretrieger): Describe font subsetting.
+In the patch subset approach to incremental font transfer a server generates binary patches which a
+client applies to a subset of the font in order to extend the coverage of that font subset. The server
+is stateless, it does not maintain any session data for clients between requests. Thus when a client
+requests the generation of a patch from the server it must fully describe the current subset of the
+font that it has in a way which allows the server to recreate it.
 
+Generic binary patch algorithms are used which do not need to be aware of the specifics of the font
+format. Typically a server will produce a patch by generating two font subsets: one which matches what
+the client currently has and one which matches the extended subset the client desires. A binary patch
+is then produced between the two subsets.
+
+### Font Subset ### {#font-subset}
+
+A subset of a font file is a modified version of the font that contains only the data needed to
+render a subset of the codepoints in the original font. A subsetted font should be able to render
+any permutation of the codepoints in the subset identically to the original font.
 
 Data Types {#data-types}
 ------------------------
@@ -371,8 +386,6 @@ transferred:
 
 ### Extending the Font Subset ### {#extend-subset}
 
-TODO(garretrieger): mention how the url identifies the specific font being requested.
-
 A client extends its font subset to cover additional codepoints by making HTTP requests to
 a Patch Subset server. The HTTP request must use either the GET or POST method:
 
@@ -383,6 +396,9 @@ a Patch Subset server. The HTTP request must use either the GET or POST method:
     <code>request</code>:<br/> the value is a single
     <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then base64url
     encoding [[rfc4648]].
+
+For both POST and GET requests the path of the request identifies the specific font. All requests
+must be made over HTTPS.
 
 The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
 as follows:
@@ -449,8 +465,6 @@ should interpret and process the fields of the object as follows:
     resend the request that triggered this response but use the new codepoint ordering provided in
     this response.
 
-TODO(garretrieger): how to handle error status codes (ie. 4xx, 5xx).
-
 ### Client Side Checksum Mismatch ### {#client-side-checksum-mismatch}
 
 If the the checksum of the font subset computed by the client does not match the
@@ -462,22 +476,18 @@ If the the checksum of the font subset computed by the client does not match the
     to the union of the codepoints in the discarded font subset and the set of code points
     the the previous request was trying to add.
 
-
 Server {#server}
 ----------------
 
 ### Responding to a PatchRequest ### {#handling-patch-request}
 
-TODO(garretrieger): url identifies the font being operated on ('the requested font')
-TODO(garretrieger): https only.
-TODO(garretrieger): Identify at least one patch format which all client/servers must support.
-
-If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> that
-was populated according to the requirements in [[#extend-subset]] then it should respond with HTTP
-status code 200. The body of the response should be a single
+If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
+HTTPS that was populated according to the requirements in [[#extend-subset]] then it should
+respond with HTTP status code 200. The body of the response should be a single
 <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.
 
-From the request object the server can produce two codepoint sets:
+The path in the request identifies the specific font that a patch is desired for. From the request
+object the server can produce two codepoint sets:
 
 1.  Codepoints the client has: formed by the union of the codepoint sets specified by
      <code>codepoints_have</code> and <code>indices_have</code>. The indices in
@@ -494,22 +504,24 @@ with a response that will cause the client to update it's codepoint ordering to 
 will recognize via the process described in [[#handling-patch-response]] and not include any patch.
 That is the <code>patch</code> and <code>replacement</code> fields must not be set.
 
-Otherwise when the response is applied by the client following the process in [[#handling-patch-response]]
-to a font subset with checksum <code>base_checksum</code> it must result in an extended font subset that contains
-data for at least the union of the set of codepoints needed and the sets of codepoints the client already
-has. The format of patch in the either the <code>patch</code> or <code>replace</code> field must be one of
-those listed in <code>accept_patch_format</code>.
+Otherwise when the response is applied by the client following the process in
+[[#handling-patch-response]] to a font subset with checksum <code>base_checksum</code> it must result
+in an extended font subset that contains data for at least the union of the set of codepoints needed
+and the sets of codepoints the client already has. The format of patch in the either the
+<code>patch</code> or <code>replace</code> field must be one of those listed in
+<code>accept_patch_format</code>.
 
-Note: the server can respond with either a patch or a replacement but should try to produce a patch where possible.
-      replacement's should only be used in situations where the server is unable to recreate the clients state
-      in order to generate a patch against it.
+Note: the server can respond with either a patch or a replacement but should try to produce a patch
+where possible. Replacement's should only be used in situations where the server is unable to recreate
+the clients state in order to generate a patch against it.
 
 Possible error responses:
 
-*  If the request is malformed the server may instead respond with http status code 400 to indicate an error.
+*  If the request is malformed the server may instead respond with http status code 400 to indicate an
+    error.
 
-*  If the requested font is not recognized by the server it may respond with http status code 404 to indicate
-    a not found error.
+*  If the requested font is not recognized by the server it may respond with http status code 404 to
+    indicate a not found error.
 
 Procedures {#procedures}
 ------------------------
@@ -533,6 +545,7 @@ TODO(garretrieger): write this.
 ### Patch and Compression Formats ### {#patch-formats}
 
 TODO(garretrieger): write this.
+TODO(garretrieger): Identify at least one patch format which all client/servers must support.
 
 Range Request Incremental Transfer {#range-request-incxfer}
 ===========================================================

--- a/Overview.bs
+++ b/Overview.bs
@@ -542,10 +542,28 @@ TODO(garretrieger): write this.
 
 TODO(garretrieger): write this.
 
-### Patch and Compression Formats ### {#patch-formats}
+### Patch Formats ### {#patch-formats}
 
-TODO(garretrieger): write this.
-TODO(garretrieger): Identify at least one patch format which all client/servers must support.
+The following patch formats may be used by the server to create binary diffs between a source file
+and a target file:
+
+<table>
+  <tr>
+    <th>Format</th><th>Value</th><th>Notes</th>
+  </tr>
+  <tr>
+    <td>VCDIFF</td><td>0</td>
+    <td>Uses VCDIFF format [[!rfc3284]] to produce the patch. All client and server implementations
+    must support this format.</td>
+  </tr>
+  <tr>
+    <td>Brotli Shared Dictionary</td><td>1</td>
+    <td>Uses brotli compression [[!rfc7932]] to produce the patch. The source file is used as a shared
+    dictionary given to the brotli compressor and decompressor.</td>
+  </tr>
+</table>
+
+TODO(garretrieger): reference updated brotli spec which includes shared dictionary.
 
 Range Request Incremental Transfer {#range-request-incxfer}
 ===========================================================

--- a/Overview.bs
+++ b/Overview.bs
@@ -358,12 +358,12 @@ transferred:
 *  Codepoint Reordering Map: The most recent [[#codepoint-reordering]] received from the server
     for this font.
 
-
 ### New Font Request ### {#rebase-request}
 
-A new font request is sent by the client to get data for a font that it has not previously requested.
-In response the server will give the client a subset of the requested font that covers the codepoints
-listed in the request. A new font request is made via HTTP and may use either the GET or POST method.
+A new font request is sent by the client to begin incrementally transferring a font. The request
+specifies a set of codepoints that the client needs to render with the font and in return the server
+will provide a copy of the font that supports at least those codepoints. A new font request is made
+via HTTP and may use either the GET or POST method.
 
 TODO(garretrieger): mention how the url identifies the specific font being requested.
 
@@ -436,11 +436,26 @@ If the server has not previously provided a <code>codepoint_ordering</code> for 
     The set of codepoints that the clients would like added to it’s copy of
     the font.
 
-
 ### Handling New Font Response ### {#handling-rebase-response}
 
-TODO(garretrieger): write this. Include info on handling client side
-                    error scenarios (ie. checksum mismatches).
+If in response to a request made for a font a client receives a [[#rebase-response]] it must:
+
+1.  Decode the contents of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> using
+     the decoder specified in <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>
+     
+2. Compute a checksum ([[#computing-checksums]]) of the decoded value of
+    <a href="#PatchResponse"><code>PatchResponse.patch</code></a>
+
+3. Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
+    the computed checksum in step 2. If they do not match this is an unrecoverable error. Do not
+    proceed to step 4.
+
+4. Replace the saved state for this font or create new saved state if none yet exists:
+    The decoded value of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> is the font
+    subset, <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
+    original font checksum, and
+    <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
+    codepoint reordering map.
 
 ### Handling Patch Font Response ### {#handling-patch-response}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -346,7 +346,18 @@ Client {#client}
 
 ### Client State ### {#client-state}
 
-TODO(garretrieger): document the state a client needs to maintain.
+The client will need to maintain at minimum the following state for each font file being incrementally
+transferred:
+
+
+*  Font subset: the binary data for the most recent version of the subset of the font being
+    incrementally transferred.
+*  Original font checksum: the most recent value of
+    <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> received
+    from the server for this font.
+*  Codepoint Reordering Map: The most recent [[#codepoint-reordering]] received from the server
+    for this font.
+
 
 ### New Font Request ### {#rebase-request}
 
@@ -585,7 +596,7 @@ Procedures {#procedures}
 
 TODO(garretrieger): write this.
 
-### Codepoint reodering ### {#codepoint-reordering}
+### Codepoint Reodering ### {#codepoint-reordering}
 
 TODO(garretrieger): write this.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -46,6 +46,8 @@ Patch Based Incremental Transfer {#patch-incxfer}
 
 TODO(garretrieger): Describe the high level version of how this version operates.
 
+TODO(garretrieger): Describe font subsetting.
+
 
 Data Types {#data-types}
 ------------------------
@@ -517,17 +519,79 @@ do not match the checksums provided in a response from the server then the clien
 Server {#server}
 ----------------
 
-TODO reorganize sections below here
+### Handling Requests ### {#handling-requests}
+
+TODO(garretrieger):
+- url identifies the font being operated on ('the requested font')
+- where to find the message.
+- CBOR decoding
+- Accepted http methods.
+- Identify at least one patch format which all client/servers must support.
 
 ### Handling New Font Request ### {#handling-rebase-request}
 
-TODO(garretrieger): write this.
+If a request is received where:
+
+* <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> is a non-empty set,
+* <a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a> is not set or is an empty set,
+* and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is not set or is an empty set;
+
+then the server must:
+
+1. Generate a subset of the requested font that contains at least the code points
+    in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.
+
+TODO(garretrieger): apply format encoding.
+
+2. Respond with a [[#rebase-response]].
 
 ### Handling Patch Font Request ### {#handling-patch-request}
 
-TODO(garretrieger): write this.
+If a request is received where:
 
-#### Client’s Original Font does not Match Server’s #### {#client-font-mismatch}
+*  At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>
+    and <a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a> is a non-empty set.
+
+*  At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a>
+    and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is a non-empty set.
+
+then the server must:
+
+1.  Determine the codepoint reordering of the requested font. See [[#codepoint-reordering]].
+
+2.  Compute the codepoint [[#reordering-checksum]] of the reordering generated in step 1.
+     If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a>
+     this is a recoverable error, follow the procedure in [[#codepoint-reordering-mismatch]].
+
+3.  Compute the checksum of the requested font. If it is not equal to
+     <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a>
+     this is a recoverable error, follow the procedure in [[#client-font-mismatch]].
+
+3.  Transform the indices_have and indices_needed sets into codepoints by applying the codepoint
+     reordering from step 1.
+   
+4.  Union the transformed indices_have and codepoints_have sets to form the base codepoint set.
+
+5.  Union the transformed indices_needed, codepoints_needed, and  base set to form the extended
+     codepoint set.
+
+6.  Generate:
+     *  The base font subset, by subsetting the requested font to exactly thecodepoints in the base
+         set.
+     *  The extended font subset, by subsetting the requested font to at least the codepoints in the
+         extended set.
+
+7.  Compute the checksum of the base font subset. If it is not equal to
+     <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> this is a recoverable
+     error, follow the procedure in [[#client-base-mismatch]].
+
+8.  Generate a binary difference between the extended font subset and the base font subset using
+     one of the patch formats listed in
+     <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.
+
+9. Respond with a [[#patch-response]].
+
+### Client’s Original Font does not Match Server’s ### {#client-font-mismatch}
 
 Over time servers may upgrade the original copies of a font with newer
 versions. After such an upgrade, clients who have subsets built from the
@@ -553,7 +617,7 @@ the current version of the font. If a mismatch is detected there are two possibl
     at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and
     <code>codepoints_needed/indices_needed</code> fields.
 
-#### Client’s Base does not Match Server’s #### {#client-base-mismatch}
+### Client’s Base does not Match Server’s ### {#client-base-mismatch}
 
 Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
 the base font that a server computes not matching the base font that a client has. This case can be
@@ -563,7 +627,7 @@ with a [[#rebase-response]] instead of the usual [[#patch-response]]. The replac
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and
 <code>codepoints_needed/indices_needed</code> fields.
 
-#### Client Codepoint Reordering does not Match Servers #### {#codepoint-reordering-mismatch}
+### Client Codepoint Reordering does not Match Servers ### {#codepoint-reordering-mismatch}
 
 The codepoint mapping used by the client may not be recognized by the server. This case can be
 detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
@@ -574,7 +638,7 @@ a [[#reindex-response]]. After receiving a [[#reindex-response]] the client shou
 If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.
 
-#### Subsetting Failures #### {#subsetting-failures}
+### Subsetting Failures ### {#subsetting-failures}
 
 ### New Font Response ### {#rebase-response}
 
@@ -592,6 +656,7 @@ If the client asks for a new font the server will respond with a single
 *  <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>:<br/>
     The compression format used to encode
     <a href="#PatchResponse"><code>PatchResponse.patch</code></a>.
+    TODO(garretrieger): needs to be one of the formats specified by the client.
    
 *  <a href="#PatchResponse"><code>PatchResponse.patch</code></a>:<br/>
     A subset of the original font that contains data for at least the codepoints requested by the
@@ -651,7 +716,7 @@ Procedures {#procedures}
 
 TODO(garretrieger): write this.
 
-### Codepoint Reodering ### {#codepoint-reordering}
+### Codepoint Reordering ### {#codepoint-reordering}
 
 TODO(garretrieger): write this.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -340,8 +340,15 @@ response_type can be one of the following values:
   <tr><td>2</td><td>REINDEX</td>
 </table>
 
-New Font Request {#rebase-request}
-----------------------------------
+
+Client {#client}
+----------------
+
+### Client State ### {#client-state}
+
+TODO(garretrieger): document the state a client needs to maintain.
+
+### New Font Request ### {#rebase-request}
 
 A new font request is sent by the client to get data for a font that it has not previously requested.
 In response the server will give the client a subset of the requested font that covers the codepoints
@@ -349,7 +356,7 @@ listed in the request. A new font request is made via HTTP and may use either th
 
 TODO(garretrieger): mention how the url identifies the specific font being requested.
 
-### POST ### {#rebase-request-post}
+#### POST #### {#rebase-request-post}
 
 If sent as a POST request the post body will be a single
 <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. All fields of
@@ -363,7 +370,7 @@ If sent as a POST request the post body will be a single
     This field should be populated with the set of <a href="#patch-formats">patch formats</a> that this
     client is capable of decoding. At least one format must be provided.
 
-### GET ### {#rebase-request-get}
+#### GET #### {#rebase-request-get}
 
 If sent as a GET request the client will include a single query parameter:
 
@@ -372,20 +379,7 @@ If sent as a GET request the client will include a single query parameter:
     and then base64url encoding [[rfc4648]]. The <a href="#PatchRequest"><code>PatchRequest</code></a>
     object uses the same fields as specified for a <a href="#rebase-request-post">POST</a> request.
 
-### Standard Response ### {#rebase-standard-response}
-
-The server will respond to a new font request with a <a href="#rebase-response">New Font Response</a>.
-
-### Errors ### {#rebase-errors}
-
-The following errors may occur as a result of a new font request:
-
-*  [[#error-font-not-found]]
-*  [[#error-bad-request]]
-*  [[#error-internal-error]]
-
-Patch Font Request {#patch-request}
------------------------------------
+### Patch Font Request ### {#patch-request}
 
 A patch font request is sent by a client to add data for additional codepoints to its font. Patch font
 requests are sent via HTTP and can only use the POST method. The request body is a single
@@ -431,12 +425,41 @@ If the server has not previously provided a <code>codepoint_ordering</code> for 
     The set of codepoints that the clients would like added to it’s copy of
     the font.
 
-### Standard Response ### {#patch-standard-response}
 
-The server will respond to a new font request with a
-<a href="#patch-response">Patch Font Response</a>.
+### Handling New Font Response ### {#handling-rebase-response}
 
-### Recoverable Errors ### {#patch-recoverable-errors}
+TODO(garretrieger): write this. Include info on handling client side
+                    error scenarios (ie. checksum mismatches).
+
+### Handling Patch Font Response ### {#handling-patch-response}
+
+TODO(garretrieger): write this.
+
+#### Client Side Patched Base Checksum Mismatch #### {#patch-mismatch}
+
+After a client receives a [[#patch-response]] and computes a new version of the font the client must
+compare the checksum [[#computing-checksums]] of the new font to
+<a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
+client must discard the response and should resend the request as a [[#rebase-request]]. Upon receiving
+a new copy of the font the client can replace any existing data it has for that font.
+
+
+### Handling Update Codepoint Ordering Response ### {#handling-reindex-response}
+
+TODO(garretrieger): write this.
+
+TODO reorganize sections below here
+
+Server {#server}
+----------------
+
+### Handling New Font Request ### {#handling-rebase-request}
+
+TODO(garretrieger): write this.
+
+### Handling Patch Font Request ### {#handling-patch-request}
+
+TODO(garretrieger): write this.
 
 #### Client’s Original Font does not Match Server’s #### {#client-font-mismatch}
 
@@ -485,30 +508,11 @@ a [[#reindex-response]]. After receiving a [[#reindex-response]] the client shou
 If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.
 
-#### Client Side Patched Base Checksum Mismatch #### {#patch-mismatch}
+#### Subsetting Failures #### {#subsetting-failures}
 
-TODO(garretrieger): this belongs with info about client handling of the response
+### New Font Response ### {#rebase-response}
 
-After a client receives a [[#patch-response]] and computes a new version of the font the client must
-compare the checksum [[#computing-checksums]] of the new font to
-<a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
-client must discard the response and should resend the request as a [[#rebase-request]]. Upon receiving
-a new copy of the font the client can replace any existing data it has for that font.
-
-#### Cmap Format 4 Overflow #### {#cmap4-overflow}
-
-#### Offset Overflow during Subsetting #### {#offset-overflow}
-
-### Errors ### {#errors}
-
-The following errors may occur as a result of a patch font request:
-
-*  [[#error-font-not-found]]
-*  [[#error-bad-request]]
-*  [[#error-internal-error]]
-
-New Font Response {#rebase-response}
----------------------------------------------
+TODO(garretrieger): update wording here to match new organization.
 
 If the client asks for a new font the server will respond with a single
 <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via COBR:
@@ -550,35 +554,52 @@ Also <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code><
 <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering_checksum</code></a> should be saved as
 they are needed for future requests.
 
+### Patch Font Response ### {#patch-response}
 
-Patch Font Response {#patch-response}
----------------------------------------------
+TODO(garretrieger): write this.
 
-Update Codepoint Ordering Response {#reindex-response}
-----------------------------------------------------------------
+### Update Codepoint Ordering Response ###  {#reindex-response}
 
-Error Response {#error-response}
-----------------------------------------
+TODO(garretrieger): write this.
 
-### Font Not Found ### {#error-font-not-found}
+### Error Response ### {#error-response}
 
-### Bad Request ### {#error-bad-request}
+TODO(garretrieger): write this.
 
-### Internal Error ### {#error-internal-error}
+#### Font Not Found #### {#error-font-not-found}
 
+TODO(garretrieger): write this.
+
+#### Bad Request #### {#error-bad-request}
+
+TODO(garretrieger): write this.
+
+#### Internal Error #### {#error-internal-error}
+
+TODO(garretrieger): write this.
 
 Procedures {#procedures}
 ------------------------
 
 ### Computing Checksums ### {#computing-checksums}
 
+TODO(garretrieger): write this.
+
 ### Codepoint reodering ### {#codepoint-reordering}
+
+TODO(garretrieger): write this.
 
 #### Computing Checksum #### {#reordering-checksum}
 
+TODO(garretrieger): write this.
+
 #### Recommended algorithm #### {#reordering-algorithm}
 
+TODO(garretrieger): write this.
+
 ### Patch and Compression Formats ### {#patch-formats}
+
+TODO(garretrieger): write this.
 
 Range Request Incremental Transfer {#range-request-incxfer}
 ===========================================================

--- a/Overview.bs
+++ b/Overview.bs
@@ -541,9 +541,10 @@ then the server must:
 1. Generate a subset of the requested font that contains at least the code points
     in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.
 
-TODO(garretrieger): apply format encoding.
+2. Encode the subset with one of the formats listed in
+    <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.
 
-2. Respond with a [[#rebase-response]].
+3. Respond with a [[#rebase-response]].
 
 ### Handling Patch Font Request ### {#handling-patch-request}
 
@@ -591,6 +592,29 @@ then the server must:
 
 9. Respond with a [[#patch-response]].
 
+### Client Codepoint Reordering does not Match Servers ### {#codepoint-reordering-mismatch}
+
+TODO(garretrieger): case where codepoint reodering differs because of a upgraded original font.
+
+The codepoint mapping used by the client may not be recognized by the server. This case can be
+detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
+checksum of the server’s codepoint reordering. In some cases the mismatch is caused by the server
+having updated the requested font with a new version which in turn can change the reordering.
+If the server still has access 
+
+*  If the codepoint ordering has changed because the requested font has been updated with a newer
+     version and the server still has the previous
+
+
+
+If there is a mismatch the server should respond with
+a [[#reindex-response]]. After receiving a [[#reindex-response]] the client should resend their
+[[#patch-request]] using the new code point reordering.
+
+If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
+the other recoverable error scenarios.
+
+
 ### Client’s Original Font does not Match Server’s ### {#client-font-mismatch}
 
 Over time servers may upgrade the original copies of a font with newer
@@ -598,18 +622,15 @@ versions. After such an upgrade, clients who have subsets built from the
 previous versions may contact the server and request a patch against the
 previous version of the font.
 
-The server will detect this case by checking that
+The server can detect this case by checking that
 <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> matches the checksum of
 the current version of the font. If a mismatch is detected there are two possible resolutions:
 
 *  Patch client to the new font. This is possible if the server has access to the font files for
-    previous versions of the font, and the provided checksum matches a previous version. The server
-    may then compute a patch between the old version of the font and the new version of the font with
-    any additional codepoints requested by the client. In this case the server should respond with a
-    [[#patch-response]]. The response should set
-    <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> to the checksum of
-    the new version of the original font. Additionally it may be necessary to send a new codepoint
-    ordering if the set of codepoints covered by the original font has changed.
+    previous versions of the font, and the provided checksum matches a previous version. Follow
+    the remaining steps in [[#handling-patch-request]] but replace the font used to generate
+    the base subset with the previous version that has a checksum matching
+    <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>.
    
 *  Replace the clients copy of the font. If the server is unable to match the provided checksum to any
     version of the font it has, then a [[#rebase-response]] should be sent instead which will instruct
@@ -627,16 +648,6 @@ with a [[#rebase-response]] instead of the usual [[#patch-response]]. The replac
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and
 <code>codepoints_needed/indices_needed</code> fields.
 
-### Client Codepoint Reordering does not Match Servers ### {#codepoint-reordering-mismatch}
-
-The codepoint mapping used by the client may not be recognized by the server. This case can be
-detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
-checksum of the server’s codepoint reordering. If there is a mismatch the server should respond with
-a [[#reindex-response]]. After receiving a [[#reindex-response]] the client should resend their
-[[#patch-request]] using the new code point reordering.
-
-If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
-the other recoverable error scenarios.
 
 ### Subsetting Failures ### {#subsetting-failures}
 

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="80e476584636c4fad7a2e033d858d37683cea357" name="document-revision">
+  <meta content="4323928b479dae1c5be34b739a2ccaeca167320f" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-11">11 May 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-12">12 May 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -473,26 +473,7 @@ dfn > a.self-link::before      { content: "#"; }
       <li>
        <a href="#server"><span class="secno">2.3</span> <span class="content">Server</span></a>
        <ol class="toc">
-        <li><a href="#handling-patch-request"><span class="secno">2.3.1</span> <span class="content">Responding to PatchRequest’s</span></a>
-        <li><a href="#patch-response"><span class="secno">2.3.2</span> <span class="content">PatchResponse</span></a>
-        <li><a href="#error-responses"><span class="secno">2.3.3</span> <span class="content">Error Responses ###</span></a>
-        <li><a href="#handling-requests"><span class="secno">2.3.4</span> <span class="content">Handling Requests</span></a>
-        <li><a href="#handling-rebase-request"><span class="secno">2.3.5</span> <span class="content">Handling New Font Request</span></a>
-        <li><a href="#handling-patch-request①"><span class="secno">2.3.6</span> <span class="content">Handling Patch Font Request</span></a>
-        <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.7</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
-        <li><a href="#client-font-mismatch"><span class="secno">2.3.8</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
-        <li><a href="#client-base-mismatch"><span class="secno">2.3.9</span> <span class="content">Client’s Base does not Match Server’s</span></a>
-        <li><a href="#subsetting-failures"><span class="secno">2.3.10</span> <span class="content">Subsetting Failures</span></a>
-        <li><a href="#rebase-response"><span class="secno">2.3.11</span> <span class="content">New Font Response</span></a>
-        <li><a href="#patch-response①"><span class="secno">2.3.12</span> <span class="content">Patch Font Response</span></a>
-        <li><a href="#reindex-response"><span class="secno">2.3.13</span> <span class="content">Update Codepoint Ordering Response</span></a>
-        <li>
-         <a href="#error-response"><span class="secno">2.3.14</span> <span class="content">Error Response</span></a>
-         <ol class="toc">
-          <li><a href="#error-font-not-found"><span class="secno">2.3.14.1</span> <span class="content">Font Not Found</span></a>
-          <li><a href="#error-bad-request"><span class="secno">2.3.14.2</span> <span class="content">Bad Request</span></a>
-          <li><a href="#error-internal-error"><span class="secno">2.3.14.3</span> <span class="content">Internal Error</span></a>
-         </ol>
+        <li><a href="#handling-patch-request"><span class="secno">2.3.1</span> <span class="content">Responding to a PatchRequest</span></a>
        </ol>
       <li>
        <a href="#procedures"><span class="secno">2.4</span> <span class="content">Procedures</span></a>
@@ -987,192 +968,41 @@ to the union of the codepoints in the discarded font subset and the set of code 
 the the previous request was trying to add.</p>
    </ol>
    <h3 class="heading settled" data-level="2.3" id="server"><span class="secno">2.3. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
-   <h4 class="heading settled" data-level="2.3.1" id="handling-patch-request"><span class="secno">2.3.1. </span><span class="content">Responding to PatchRequest’s</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <h4 class="heading settled" data-level="2.3.1" id="handling-patch-request"><span class="secno">2.3.1. </span><span class="content">Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <p>TODO(garretrieger): url identifies the font being operated on ('the requested font')
+TODO(garretrieger): https only.
+TODO(garretrieger): Identify at least one patch format which all client/servers must support.</p>
    <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> that
 was populated according to the requirements in <a href="#extend-subset">§ 2.2.2 Extending the Font Subset</a> then it should respond with HTTP
 status code 200. The body of the response should be a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>
-   <p>TODO(garretrieger): describe producing two codepoint sets - codepoints needed, codepoints have
-TODO(garretrieger): say something about original font checksum? it doesn’t need to match...
-TODO(garretrieger): note the server should try and produce a patch instead of a replacement
-                    where possible.</p>
-   <p>The response object must:</p>
-   <ul>
+   <p>From the request object the server can produce two codepoint sets:</p>
+   <ol>
     <li data-md>
-     <p>when processed by the client according to <a href="#handling-patch-response">§ 2.2.3 Handling PatchResponse</a> result in a font subset
-that contains data for at least the union of the set of codepoints needed and the sets of
-codepoints the client already has. The format of the used patch in the response must be one of
+     <p>Codepoints the client has: formed by the union of the codepoint sets specified by <code>codepoints_have</code> and <code>indices_have</code>. The indices in <code>indices_have</code> must be mapped to codepoints by the application of the
+ codepoint reordering with a checksum matching <code>ordering_checksum</code>.</p>
+    <li data-md>
+     <p>Codepoints the client needs: formed by the union of the codepoint sets specified by <code>codepoints_needed</code> and <code>indices_needed</code>. The indices in <code>indices_have</code> must be mapped to codepoints by the application of the
+ codepoint reordering with a checksum matching <code>ordering_checksum</code>.</p>
+   </ol>
+   <p>If the server does not recognize the codepoint ordering used by the client, it must respond
+with a response that will cause the client to update it’s codepoint ordering to one the server
+will recognize via the process described in <a href="#handling-patch-response">§ 2.2.3 Handling PatchResponse</a> and not include any patch.
+That is the <code>patch</code> and <code>replacement</code> fields must not be set.</p>
+   <p>Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 2.2.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result in an extended font subset that contains
+data for at least the union of the set of codepoints needed and the sets of codepoints the client already
+has. The format of patch in the either the <code>patch</code> or <code>replace</code> field must be one of
 those listed in <code>accept_patch_format</code>.</p>
-    <li data-md>
-     <p>OR, ... TODO(garretrieger): alternately can respond just with an updated codepoint ordering.</p>
-   </ul>
-   <p>The fields should
-be set as follows</p>
-   <h4 class="heading settled" data-level="2.3.2" id="patch-response"><span class="secno">2.3.2. </span><span class="content">PatchResponse</span><a class="self-link" href="#patch-response"></a></h4>
-   <h4 class="heading settled" data-level="2.3.3" id="error-responses"><span class="secno">2.3.3. </span><span class="content">Error Responses ###</span><a class="self-link" href="#error-responses"></a></h4>
-   <p>///////////////// OLD</p>
-   <h4 class="heading settled" data-level="2.3.4" id="handling-requests"><span class="secno">2.3.4. </span><span class="content">Handling Requests</span><a class="self-link" href="#handling-requests"></a></h4>
-   <p>TODO(garretrieger):</p>
+   <p class="note" role="note"><span>Note:</span> the server can respond with either a patch or a replacement but should try to produce a patch where possible.
+      replacement’s should only be used in situations where the server is unable to recreate the clients state
+      in order to generate a patch against it.</p>
+   <p>Possible error responses:</p>
    <ul>
     <li data-md>
-     <p>url identifies the font being operated on ('the requested font')</p>
+     <p>If the request is malformed the server may instead respond with http status code 400 to indicate an error.</p>
     <li data-md>
-     <p>where to find the message.</p>
-    <li data-md>
-     <p>CBOR decoding</p>
-    <li data-md>
-     <p>Accepted http methods.</p>
-    <li data-md>
-     <p>Identify at least one patch format which all client/servers must support.</p>
+     <p>If the requested font is not recognized by the server it may respond with http status code 404 to indicate
+a not found error.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.3.5" id="handling-rebase-request"><span class="secno">2.3.5. </span><span class="content">Handling New Font Request</span><a class="self-link" href="#handling-rebase-request"></a></h4>
-   <p>If a request is received where:</p>
-   <ul>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> is a non-empty set,</p>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a> is not set or is an empty set,</p>
-    <li data-md>
-     <p>and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is not set or is an empty set;</p>
-   </ul>
-   <p>then the server must:</p>
-   <ol>
-    <li data-md>
-     <p>Generate a subset of the requested font that contains at least the code points
-in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
-    <li data-md>
-     <p>Encode the subset with one of the formats listed in <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.</p>
-    <li data-md>
-     <p>Respond with a <a href="#rebase-response">§ 2.3.11 New Font Response</a>.</p>
-   </ol>
-   <h4 class="heading settled" data-level="2.3.6" id="handling-patch-request①"><span class="secno">2.3.6. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request①"></a></h4>
-   <p>If a request is received where:</p>
-   <ul>
-    <li data-md>
-     <p>At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> and <a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a> is a non-empty set.</p>
-    <li data-md>
-     <p>At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a> and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is a non-empty set.</p>
-   </ul>
-   <p>then the server must:</p>
-   <ol>
-    <li data-md>
-     <p>Determine the codepoint reordering of the requested font. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a>.</p>
-    <li data-md>
-     <p>Compute the codepoint <a href="#reordering-checksum">§ 2.4.2.1 Computing Checksum</a> of the reordering generated in step 1.
- If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> this is a recoverable error, follow the procedure in <a href="#codepoint-reordering-mismatch">§ 2.3.7 Client Codepoint Reordering does not Match Servers</a>.</p>
-    <li data-md>
-     <p>Compute the checksum of the requested font. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a> this is a recoverable error, follow the procedure in <a href="#client-font-mismatch">§ 2.3.8 Client’s Original Font does not Match Server’s</a>.</p>
-    <li data-md>
-     <p>Transform the indices_have and indices_needed sets into codepoints by applying the codepoint
- reordering from step 1.</p>
-    <li data-md>
-     <p>Union the transformed indices_have and codepoints_have sets to form the base codepoint set.</p>
-    <li data-md>
-     <p>Union the transformed indices_needed, codepoints_needed, and  base set to form the extended
- codepoint set.</p>
-    <li data-md>
-     <p>Generate:</p>
-     <ul>
-      <li data-md>
-       <p>The base font subset, by subsetting the requested font to exactly thecodepoints in the base
- set.</p>
-      <li data-md>
-       <p>The extended font subset, by subsetting the requested font to at least the codepoints in the
- extended set.</p>
-     </ul>
-    <li data-md>
-     <p>Compute the checksum of the base font subset. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> this is a recoverable
- error, follow the procedure in <a href="#client-base-mismatch">§ 2.3.9 Client’s Base does not Match Server’s</a>.</p>
-    <li data-md>
-     <p>Generate a binary difference between the extended font subset and the base font subset using
- one of the patch formats listed in <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.</p>
-    <li data-md>
-     <p>Respond with a <a href="#patch-response">§ 2.3.2 PatchResponse</a>.</p>
-   </ol>
-   <h4 class="heading settled" data-level="2.3.7" id="codepoint-reordering-mismatch"><span class="secno">2.3.7. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h4>
-   <p>TODO(garretrieger): case where codepoint reodering differs because of a upgraded original font.</p>
-   <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
-detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
-checksum of the server’s codepoint reordering. In some cases the mismatch is caused by the server
-having updated the requested font with a new version which in turn can change the reordering.
-If the server still has access</p>
-   <ul>
-    <li data-md>
-     <p>If the codepoint ordering has changed because the requested font has been updated with a newer
- version and the server still has the previous</p>
-   </ul>
-   <p>If there is a mismatch the server should respond with
-a <a href="#reindex-response">§ 2.3.13 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.13 Update Codepoint Ordering Response</a> the client should resend their
-#patch-request (TODO) using the new code point reordering.</p>
-   <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
-the other recoverable error scenarios.</p>
-   <h4 class="heading settled" data-level="2.3.8" id="client-font-mismatch"><span class="secno">2.3.8. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h4>
-   <p>Over time servers may upgrade the original copies of a font with newer
-versions. After such an upgrade, clients who have subsets built from the
-previous versions may contact the server and request a patch against the
-previous version of the font.</p>
-   <p>The server can detect this case by checking that <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> matches the checksum of
-the current version of the font. If a mismatch is detected there are two possible resolutions:</p>
-   <ul>
-    <li data-md>
-     <p>Patch client to the new font. This is possible if the server has access to the font files for
-previous versions of the font, and the provided checksum matches a previous version. Follow
-the remaining steps in <a href="#handling-patch-request">§ 2.3.1 Responding to PatchRequest’s</a> but replace the font used to generate
-the base subset with the previous version that has a checksum matching <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>.</p>
-    <li data-md>
-     <p>Replace the clients copy of the font. If the server is unable to match the provided checksum to any
-version of the font it has, then a <a href="#rebase-response">§ 2.3.11 New Font Response</a> should be sent instead which will instruct
-the client to replace the version they have with the newer version. The replacement font must cover
-at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
-   </ul>
-   <h4 class="heading settled" data-level="2.3.9" id="client-base-mismatch"><span class="secno">2.3.9. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h4>
-   <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
-the base font that a server computes not matching the base font that a client has. This case can be
-detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
-with a <a href="#rebase-response">§ 2.3.11 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.2 PatchResponse</a>. The replacement font must cover
-at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
-   <h4 class="heading settled" data-level="2.3.10" id="subsetting-failures"><span class="secno">2.3.10. </span><span class="content">Subsetting Failures</span><a class="self-link" href="#subsetting-failures"></a></h4>
-   <h4 class="heading settled" data-level="2.3.11" id="rebase-response"><span class="secno">2.3.11. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h4>
-   <p>TODO(garretrieger): update wording here to match new organization.</p>
-   <p>If the client asks for a new font the server will respond with a single <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via COBR:</p>
-   <ul>
-    <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.response_type</code></a>:<br> is set to REBASE.</p>
-    <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>:<br> The checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) computed for the full unmodified original font.</p>
-    <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>:<br> The compression format used to encode <a href="#PatchResponse"><code>PatchResponse.patch</code></a>.
-TODO(garretrieger): needs to be one of the formats specified by the client.</p>
-    <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.patch</code></a>:<br> A subset of the original font that contains data for at least the codepoints requested by the
-client in the <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> field. The
-server may opt to expand the subset requested by the client to include additional characters that
-may be needed for future content. The font subset is compressed by the format specified in <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>.</p>
-    <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a>:<br> The checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) computed for the subsetted font,
-prior to compression.</p>
-    <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>:<br> The server should provide a codepoint reordering which the client will use to
-communicate codepoint sets back to the server. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> for details. The
-server is free to chose the mapping, but the mapping must use only code points in
-the original font and must map all codepoints in the original font.</p>
-    <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a>:<br> Checksum for the codepoint ordering <a href="#reordering-checksum">§ 2.4.2.1 Computing Checksum</a>.</p>
-   </ul>
-   <p>If the client receives a new font response it should replace any version of the font it currently has
-with the decompressed contents of the <a href="#PatchResponse"><code>PatchResponse.patch</code></a> Also <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>, <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>, and <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering_checksum</code></a> should be saved as
-they are needed for future requests.</p>
-   <h4 class="heading settled" data-level="2.3.12" id="patch-response①"><span class="secno">2.3.12. </span><span class="content">Patch Font Response</span><a class="self-link" href="#patch-response①"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.3.13" id="reindex-response"><span class="secno">2.3.13. </span><span class="content">Update Codepoint Ordering Response</span><a class="self-link" href="#reindex-response"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.3.14" id="error-response"><span class="secno">2.3.14. </span><span class="content">Error Response</span><a class="self-link" href="#error-response"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.14.1" id="error-font-not-found"><span class="secno">2.3.14.1. </span><span class="content">Font Not Found</span><a class="self-link" href="#error-font-not-found"></a></h5>
-   <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.14.2" id="error-bad-request"><span class="secno">2.3.14.2. </span><span class="content">Bad Request</span><a class="self-link" href="#error-bad-request"></a></h5>
-   <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.14.3" id="error-internal-error"><span class="secno">2.3.14.3. </span><span class="content">Internal Error</span><a class="self-link" href="#error-internal-error"></a></h5>
-   <p>TODO(garretrieger): write this.</p>
    <h3 class="heading settled" data-level="2.4" id="procedures"><span class="secno">2.4. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
    <h4 class="heading settled" data-level="2.4.1" id="computing-checksums"><span class="secno">2.4.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
    <p>TODO(garretrieger): write this.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="a965058fb5f54c3ed8df0bd866d5d0f56ae06fbc" name="document-revision">
+  <meta content="181d77a1915f5f9c92401b69acccec9801ebbe76" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -909,9 +909,10 @@ from the server for this font.</p>
 for this font.</p>
    </ul>
    <h4 class="heading settled" data-level="2.2.2" id="rebase-request"><span class="secno">2.2.2. </span><span class="content">New Font Request</span><a class="self-link" href="#rebase-request"></a></h4>
-   <p>A new font request is sent by the client to get data for a font that it has not previously requested.
-In response the server will give the client a subset of the requested font that covers the codepoints
-listed in the request. A new font request is made via HTTP and may use either the GET or POST method.</p>
+   <p>A new font request is sent by the client to begin incrementally transferring a font. The request
+specifies a set of codepoints that the client needs to render with the font and in return the server
+will provide a copy of the font that supports at least those codepoints. A new font request is made
+via HTTP and may use either the GET or POST method.</p>
    <p>TODO(garretrieger): mention how the url identifies the specific font being requested.</p>
    <h5 class="heading settled" data-level="2.2.2.1" id="rebase-request-post"><span class="secno">2.2.2.1. </span><span class="content">POST</span><a class="self-link" href="#rebase-request-post"></a></h5>
    <p>If sent as a POST request the post body will be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. All fields of <a href="#PatchRequest"><code>PatchRequest</code></a> should be left unset except for:</p>
@@ -967,8 +968,24 @@ The codepoint values are transformed to indices by applying <code>codepoint orde
 the font.</p>
    </ul>
    <h4 class="heading settled" data-level="2.2.4" id="handling-rebase-response"><span class="secno">2.2.4. </span><span class="content">Handling New Font Response</span><a class="self-link" href="#handling-rebase-response"></a></h4>
-   <p>TODO(garretrieger): write this. Include info on handling client side
-                    error scenarios (ie. checksum mismatches).</p>
+   <p>If in response to a request made for a font a client receives a <a href="#rebase-response">§ 2.3.3 New Font Response</a> it must:</p>
+   <ol>
+    <li data-md>
+     <p>Decode the contents of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> using
+ the decoder specified in <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a></p>
+    <li data-md>
+     <p>Compute a checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) of the decoded value of <a href="#PatchResponse"><code>PatchResponse.patch</code></a></p>
+    <li data-md>
+     <p>Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
+the computed checksum in step 2. If they do not match this is an unrecoverable error. Do not
+proceed to step 4.</p>
+    <li data-md>
+     <p>Replace the saved state for this font or create new saved state if none yet exists:
+The decoded value of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> is the font
+subset, <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
+original font checksum, and <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
+codepoint reordering map.</p>
+   </ol>
    <h4 class="heading settled" data-level="2.2.5" id="handling-patch-response"><span class="secno">2.2.5. </span><span class="content">Handling Patch Font Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
    <p>TODO(garretrieger): write this.</p>
    <h5 class="heading settled" data-level="2.2.5.1" id="patch-mismatch"><span class="secno">2.2.5.1. </span><span class="content">Client Side Patched Base Checksum Mismatch</span><a class="self-link" href="#patch-mismatch"></a></h5>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="6ebf275627bfa960df0fe5253a15120921ff3c42" name="document-revision">
+  <meta content="a965058fb5f54c3ed8df0bd866d5d0f56ae06fbc" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -509,7 +509,7 @@ dfn > a.self-link::before      { content: "#"; }
        <ol class="toc">
         <li><a href="#computing-checksums"><span class="secno">2.4.1</span> <span class="content">Computing Checksums</span></a>
         <li>
-         <a href="#codepoint-reordering"><span class="secno">2.4.2</span> <span class="content">Codepoint reodering</span></a>
+         <a href="#codepoint-reordering"><span class="secno">2.4.2</span> <span class="content">Codepoint Reodering</span></a>
          <ol class="toc">
           <li><a href="#reordering-checksum"><span class="secno">2.4.2.1</span> <span class="content">Computing Checksum</span></a>
           <li><a href="#reordering-algorithm"><span class="secno">2.4.2.2</span> <span class="content">Recommended algorithm</span></a>
@@ -895,7 +895,19 @@ bit set and the list of ranges are unioned together.</p>
    </table>
    <h3 class="heading settled" data-level="2.2" id="client"><span class="secno">2.2. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
    <h4 class="heading settled" data-level="2.2.1" id="client-state"><span class="secno">2.2.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
-   <p>TODO(garretrieger): document the state a client needs to maintain.</p>
+   <p>The client will need to maintain at minimum the following state for each font file being incrementally
+transferred:</p>
+   <ul>
+    <li data-md>
+     <p>Font subset: the binary data for the most recent version of the subset of the font being
+incrementally transferred.</p>
+    <li data-md>
+     <p>Original font checksum: the most recent value of <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> received
+from the server for this font.</p>
+    <li data-md>
+     <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> received from the server
+for this font.</p>
+   </ul>
    <h4 class="heading settled" data-level="2.2.2" id="rebase-request"><span class="secno">2.2.2. </span><span class="content">New Font Request</span><a class="self-link" href="#rebase-request"></a></h4>
    <p>A new font request is sent by the client to get data for a font that it has not previously requested.
 In response the server will give the client a subset of the requested font that covers the codepoints
@@ -941,10 +953,10 @@ font the client should set:</p>
 response from the server for this particular font.</p>
     <li data-md>
      <p><a href="#PatchRequest"><code>PatchRequest.indices_have</code></a>:<br> Encodes the set of codepoints that are covered by the client’s current copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint reodering</a> to each codepoint value.</p>
+The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> to each codepoint value.</p>
     <li data-md>
      <p><a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a>:<br> Encodes the set of codepoints that the clients would like added to it’s copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint reodering</a> to each codepoint value.</p>
+The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> to each codepoint value.</p>
    </ul>
    <p>If the server has not previously provided a <code>codepoint_ordering</code> for this font then the <code>codepoints_have</code> and <code>codepoints_needed</code> fields should be used instead:</p>
    <ul>
@@ -1027,7 +1039,7 @@ may be needed for future content. The font subset is compressed by the format sp
 prior to compression.</p>
     <li data-md>
      <p><a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>:<br> The server should provide a codepoint reordering which the client will use to
-communicate codepoint sets back to the server. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint reodering</a> for details. The
+communicate codepoint sets back to the server. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> for details. The
 server is free to chose the mapping, but the mapping must use only code points in
 the original font and must map all codepoints in the original font.</p>
     <li data-md>
@@ -1051,7 +1063,7 @@ they are needed for future requests.</p>
    <h3 class="heading settled" data-level="2.4" id="procedures"><span class="secno">2.4. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
    <h4 class="heading settled" data-level="2.4.1" id="computing-checksums"><span class="secno">2.4.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.4.2" id="codepoint-reordering"><span class="secno">2.4.2. </span><span class="content">Codepoint reodering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
+   <h4 class="heading settled" data-level="2.4.2" id="codepoint-reordering"><span class="secno">2.4.2. </span><span class="content">Codepoint Reodering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
    <p>TODO(garretrieger): write this.</p>
    <h5 class="heading settled" data-level="2.4.2.1" id="reordering-checksum"><span class="secno">2.4.2.1. </span><span class="content">Computing Checksum</span><a class="self-link" href="#reordering-checksum"></a></h5>
    <p>TODO(garretrieger): write this.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="971fbaf0e28da93ce0b506148767af37bb347e0c" name="document-revision">
+  <meta content="9589728b22e2193405d001b8ae19ec641c8f0b7b" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -466,17 +466,9 @@ dfn > a.self-link::before      { content: "#"; }
        <a href="#client"><span class="secno">2.2</span> <span class="content">Client</span></a>
        <ol class="toc">
         <li><a href="#client-state"><span class="secno">2.2.1</span> <span class="content">Client State</span></a>
-        <li>
-         <a href="#rebase-request"><span class="secno">2.2.2</span> <span class="content">New Font Request</span></a>
-         <ol class="toc">
-          <li><a href="#rebase-request-post"><span class="secno">2.2.2.1</span> <span class="content">POST</span></a>
-          <li><a href="#rebase-request-get"><span class="secno">2.2.2.2</span> <span class="content">GET</span></a>
-         </ol>
-        <li><a href="#patch-request"><span class="secno">2.2.3</span> <span class="content">Patch Font Request</span></a>
-        <li><a href="#handling-rebase-response"><span class="secno">2.2.4</span> <span class="content">Handling New Font Response</span></a>
-        <li><a href="#handling-patch-response"><span class="secno">2.2.5</span> <span class="content">Handling Patch Font Response</span></a>
-        <li><a href="#handling-reindex-response"><span class="secno">2.2.6</span> <span class="content">Handling Update Codepoint Ordering Response</span></a>
-        <li><a href="#client-side-checksum-mismatch"><span class="secno">2.2.7</span> <span class="content">Client Side Checksum Mismatch</span></a>
+        <li><a href="#extend-subset"><span class="secno">2.2.2</span> <span class="content">Extending the Font Subset</span></a>
+        <li><a href="#handling-patch-response"><span class="secno">2.2.3</span> <span class="content">Handling PatchResponse</span></a>
+        <li><a href="#client-side-checksum-mismatch"><span class="secno">2.2.4</span> <span class="content">Client Side Checksum Mismatch</span></a>
        </ol>
       <li>
        <a href="#server"><span class="secno">2.3</span> <span class="content">Server</span></a>
@@ -805,23 +797,23 @@ bit set and the list of ranges are unioned together.</p>
       <td>Integer
      <tr>
       <td>1
-      <td>original_font_checksum
-      <td>Integer
-     <tr>
-      <td>2
-      <td>base_checksum
-      <td>Integer
-     <tr>
-      <td>3
-      <td>patch_format
+      <td>accept_patch_format
       <td>ArrayOf&lt;Integer>
      <tr>
-      <td>4
+      <td>2
       <td>codepoints_have
       <td>CompressedSet
      <tr>
-      <td>5
+      <td>3
       <td>codepoints_needed
+      <td>CompressedSet
+     <tr>
+      <td>4
+      <td>indices_have
+      <td>CompressedSet
+     <tr>
+      <td>5
+      <td>indices_needed
       <td>CompressedSet
      <tr>
       <td>6
@@ -829,14 +821,25 @@ bit set and the list of ranges are unioned together.</p>
       <td>Integer
      <tr>
       <td>7
-      <td>indices_have
-      <td>CompressedSet
+      <td>original_font_checksum
+      <td>Integer
      <tr>
       <td>8
-      <td>indices_needed
-      <td>CompressedSet
+      <td>base_checksum
+      <td>Integer
    </table>
-   <p>patch_format can include be any of the values specified in <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a>.</p>
+   <p>For a PatchRequest object to be well formed:</p>
+   <ul>
+    <li data-md>
+     <p><code>protocol_version</code> must be set to 0.</p>
+    <li data-md>
+     <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a>.</p>
+    <li data-md>
+     <p>If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
+then <code>ordering_checksum</code> must be set.</p>
+    <li data-md>
+     <p>If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then <code>original_font_checksum</code> and <code>base_checksum</code> must be set.</p>
+   </ul>
    <h5 class="heading settled" data-level="2.1.5.4" id="PatchResponse"><span class="secno">2.1.5.4. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h5>
    <table>
     <tbody>
@@ -846,57 +849,52 @@ bit set and the list of ranges are unioned together.</p>
       <th>Value Type
      <tr>
       <td>0
-      <td>response_type
-      <td>Integer
-     <tr>
-      <td>1
-      <td>original_font_checksum
-      <td>Integer
-     <tr>
-      <td>2
       <td>patch_format
       <td>Integer
      <tr>
-      <td>3
+      <td>1
       <td>patch
       <td>ByteString
+     <tr>
+      <td>2
+      <td>replacement
+      <td>ByteString
+     <tr>
+      <td>3
+      <td>original_font_checksum
+      <td>Integer
      <tr>
       <td>4
       <td>patched_checksum
       <td>Integer
      <tr>
-      <td>4
+      <td>5
       <td>codepoint_ordering
       <td>CompressedList
      <tr>
-      <td>5
+      <td>6
       <td>ordering_checksum
       <td>Integer
    </table>
-   <p>response_type can be one of the following values:</p>
-   <table>
-    <tbody>
-     <tr>
-      <th>Value
-      <th>Response Type
-     <tr>
-      <td>0
-      <td>PATCH
-     <tr>
-      <td>1
-      <td>REBASE
-     <tr>
-      <td>2
-      <td>REINDEX
-   </table>
+   <p>For a PatchRequest object to be well formed:</p>
+   <ul>
+    <li data-md>
+     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a></p>
+    <li data-md>
+     <p>Only one of <code>patch</code> and <code>replacement</code> may be set.</p>
+    <li data-md>
+     <p>If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>, <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</p>
+    <li data-md>
+     <p>If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.</p>
+   </ul>
    <h3 class="heading settled" data-level="2.2" id="client"><span class="secno">2.2. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
    <h4 class="heading settled" data-level="2.2.1" id="client-state"><span class="secno">2.2.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
    <p>The client will need to maintain at minimum the following state for each font file being incrementally
 transferred:</p>
    <ul>
     <li data-md>
-     <p>Font subset: the binary data for the most recent version of the subset of the font being
-incrementally transferred.</p>
+     <p>Font subset: a byte array containing the binary data for the most recent version of the subset of
+the font being incrementally transferred. For a new font this is initialized to empty byte array.</p>
     <li data-md>
      <p>Original font checksum: the most recent value of <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
 from the server for this font.</p>
@@ -906,127 +904,83 @@ for this font.</p>
     <li data-md>
      <p>Codepoint Reordering Checksum: The most recent <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> for this font.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.2.2" id="rebase-request"><span class="secno">2.2.2. </span><span class="content">New Font Request</span><a class="self-link" href="#rebase-request"></a></h4>
-   <p>A new font request is sent by the client to begin incrementally transferring a font. The request
-specifies a set of codepoints that the client needs to render with the font and in return the server
-will provide a copy of the font that supports at least those codepoints. A new font request is made
-via HTTP and may use either the GET or POST method.</p>
+   <h4 class="heading settled" data-level="2.2.2" id="extend-subset"><span class="secno">2.2.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
    <p>TODO(garretrieger): mention how the url identifies the specific font being requested.</p>
-   <h5 class="heading settled" data-level="2.2.2.1" id="rebase-request-post"><span class="secno">2.2.2.1. </span><span class="content">POST</span><a class="self-link" href="#rebase-request-post"></a></h5>
-   <p>If sent as a POST request the post body will be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. All fields of <a href="#PatchRequest"><code>PatchRequest</code></a> should be left unset except for:</p>
+   <p>A client extends its font subset to cover additional codepoints by making HTTP requests to
+a Patch Subset server. The HTTP request must use either the GET or POST method:</p>
    <ul>
     <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>:<br> This field is be populated with the <a href="#CompressedSet">set</a> of
-unicode codepoints which the client requires data for.</p>
+     <p>If sent as a POST request the post body will be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.</p>
     <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>:<br> This field should be populated with the set of <a href="#patch-formats">patch formats</a> that this
-client is capable of decoding. At least one format must be provided.</p>
+     <p>If sent as a GET request the client will include a single query parameter, <code>request</code>:<br> the value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then base64url
+encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>.</p>
    </ul>
-   <h5 class="heading settled" data-level="2.2.2.2" id="rebase-request-get"><span class="secno">2.2.2.2. </span><span class="content">GET</span><a class="self-link" href="#rebase-request-get"></a></h5>
-   <p>If sent as a GET request the client will include a single query parameter:</p>
+   <p>The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
+as follows:</p>
    <ul>
     <li data-md>
-     <p><code>request</code>:<br> The value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR
-and then base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>. The <a href="#PatchRequest"><code>PatchRequest</code></a> object uses the same fields as specified for a <a href="#rebase-request-post">POST</a> request.</p>
+     <p><code>protocol_version</code>: set to 0.</p>
+    <li data-md>
+     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a> that this client is
+capable of decoding. Must contain at least one format.</p>
+    <li data-md>
+     <p><code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
+contains data for. If the current font subset is an empty byte array this field is left unset.
+If the client has a codepoint ordering for this font then this field should not be set.</p>
+    <li data-md>
+     <p><code>codepoints_needed</code>: set to the set of codepoints that the client wants to
+add to its font subset. If the client has a codepoint ordering for this font then this
+field should not be set.</p>
+    <li data-md>
+     <p><code>indices_have</code>: encodes the set of codepoints that the current
+font subset contains data for. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+ordering for this font then this field should not be set.</p>
+    <li data-md>
+     <p><code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
+font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+ordering for this font then this field should not be set.</p>
+    <li data-md>
+     <p><code>ordering_checksum</code>: If either of <code>indices_have</code> or <code>indices_needed</code> is set then this must be set to the current value of <code>ordering_checksum</code> saved in the state for this font.</p>
+    <li data-md>
+     <p><code>original_font_checksum</code>:
+Set to saved value for <code>original_font_checksum</code> in the state for this font. If
+there is no saved value leave this field unset.</p>
+    <li data-md>
+     <p><code>base_checksum</code>:
+Set to the checksum of the font subset byte array saved in the state for this font. See: <a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.2.3" id="patch-request"><span class="secno">2.2.3. </span><span class="content">Patch Font Request</span><a class="self-link" href="#patch-request"></a></h4>
-   <p>A patch font request is sent by a client to add data for additional codepoints to its font. Patch font
-requests are sent via HTTP and can only use the POST method. The request body is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. The fields of
-should be set as follows:</p>
-   <ul>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>:<br> Set to the last saved value of original_font_checksum provided by a
-previous response from the server for this particular font.</p>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a>:<br> Set to the checksum <a href="#computing-checksums">§ 2.4.1 Computing Checksums</a> of the client’s most recent
-copy of the font.</p>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>:<br> This field should be populated with the set of <a href="#patch-formats">patch formats</a> that this
-client is capable of decoding. At least one format must be provided.</p>
-   </ul>
-   <p>If the server has previously provided a <code>codepoint_ordering</code> for this
-font the client should set:</p>
-   <ul>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a>:<br> Set to the most recent value of <code>ordering_checksum</code> provided by a
-response from the server for this particular font.</p>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.indices_have</code></a>:<br> Encodes the set of codepoints that are covered by the client’s current copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value.</p>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a>:<br> Encodes the set of codepoints that the clients would like added to it’s copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value.</p>
-   </ul>
-   <p>If the server has not previously provided a <code>codepoint_ordering</code> for this font then the <code>codepoints_have</code> and <code>codepoints_needed</code> fields should be used instead:</p>
-   <ul>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a>:<br> The set of codepoints that are covered by the client’s copy of the font.</p>
-    <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>:<br> The set of codepoints that the clients would like added to it’s copy of
-the font.</p>
-   </ul>
-   <h4 class="heading settled" data-level="2.2.4" id="handling-rebase-response"><span class="secno">2.2.4. </span><span class="content">Handling New Font Response</span><a class="self-link" href="#handling-rebase-response"></a></h4>
-   <p>If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a> is equal to REBASE, then the client must:</p>
+   <h4 class="heading settled" data-level="2.2.3" id="handling-patch-response"><span class="secno">2.2.3. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h4>
+   <p>If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a> if will respond with HTTP status code 200 and the body of the response will be a <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
+should interpret and process the fields of the object as follows:</p>
    <ol>
     <li data-md>
-     <p>Decode the contents of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> using
- the decoder specified in <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a></p>
+     <p>If field <code>replacement</code> is set then: the byte array in this field is a binary patch
+ in the format specified by <code>patch_format</code>. Apply the binary patch to a base which
+ is a empty byte array. Replace the saved font subset with the result of the patch application.</p>
     <li data-md>
-     <p>Compute a checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) of the decoded value of <a href="#PatchResponse"><code>PatchResponse.patch</code></a></p>
+     <p>If field <code>patch</code> is set then:  the byte array in this field is a binary patch
+in the format specified by <code>patch_format</code>. Apply the binary patch to the saved font
+subset. Replace the saved font subset with the result of the patch application.</p>
     <li data-md>
-     <p>Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
-the computed checksum in step 2. If they do not match this is an unrecoverable error. Do not
-proceed to step 4.</p>
+     <p>If either <code>replacement</code> or <code>patch</code> is set then: <a href="#computing-checksums">compute the checksum</a> of the font subset produced by the patch
+application in steps 1 or 2. If the computed checksum is not equal to <code>patched_checksum</code> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.4 Client Side Checksum Mismatch</a>. Otherwise
+update the saved original font checksum with the value in <code>original_font_checksum</code>.</p>
     <li data-md>
-     <p>Replace the saved state for this font or create new saved state if none yet exists:
-The decoded value of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> is the font
-subset, <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
-original font checksum, and <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> is the
-codepoint reordering map.</p>
+     <p>If fields <code>codepoint_ordering</code> and <code>ordering_checksum</code> are set then update
+the saved codepoint ordering and checksum with the new values specified by these two fields.
+If neither <code>replacement</code> or <code>patch</code> are set, then the client should
+resend the request that triggered this response but use the new codepoint ordering provided in
+this response.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.2.5" id="handling-patch-response"><span class="secno">2.2.5. </span><span class="content">Handling Patch Font Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
-   <p>If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a> is equal to PATCH, then the client must:</p>
-   <ol>
-    <li data-md>
-     <p>Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> matches the original font checksum stored in the clients state. If they do not match
- this is a recoverable error, follow the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.7 Client Side Checksum Mismatch</a>.</p>
-    <li data-md>
-     <p>Apply the decoded patch to the client’s font subset. The format of the patch is specified
- by the <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a> field. This
- produces a extended font subset. Replace the previous font subset stored in the client’s
- state with this the new one.</p>
-    <li data-md>
-     <p>Compute the checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) of the extended font subset.</p>
-    <li data-md>
-     <p>Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
- the computed checksum in step 3. If they do not match this is a recoverable error, follow
- the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.7 Client Side Checksum Mismatch</a>.</p>
-    <li data-md>
-     <p>If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
- then replace the codepoint ordering and checksum saved in the clients state with the new one
- specified in the response.</p>
-   </ol>
-   <h4 class="heading settled" data-level="2.2.6" id="handling-reindex-response"><span class="secno">2.2.6. </span><span class="content">Handling Update Codepoint Ordering Response</span><a class="self-link" href="#handling-reindex-response"></a></h4>
-   <p>If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a> is equal to REINDEX, then the client must:</p>
-   <ol>
-    <li data-md>
-     <p>Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> matches the original font checksum stored in the clients state. If they do not match
- this is a recoverable error, follow the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.7 Client Side Checksum Mismatch</a>.</p>
-    <li data-md>
-     <p>If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
- then replace the codepoint ordering and checksum saved in the clients state with the new one
- specified in the response.</p>
-    <li data-md>
-     <p>Resend the request which triggered this response using the new codepoint ordering.</p>
-   </ol>
-   <h4 class="heading settled" data-level="2.2.7" id="client-side-checksum-mismatch"><span class="secno">2.2.7. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
-   <p>If either the clients saved original font checksum or the checksum of the patched font subset
-do not match the checksums provided in a response from the server then the client should:</p>
+   <h4 class="heading settled" data-level="2.2.4" id="client-side-checksum-mismatch"><span class="secno">2.2.4. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
+   <p>If the the checksum of the font subset computed by the client does not match the <code>patched_checksum</code> in the server’s response then the client should:</p>
    <ol>
     <li data-md>
      <p>Discard all currently saved state for this font.</p>
     <li data-md>
-     <p>Resend the request as a <a href="#rebase-request">§ 2.2.2 New Font Request</a> with the codepoints that are currently needed.</p>
+     <p><a href="#extend-subset">Resend the request</a>. Set the <code>codepoints_needed</code> field
+to the union of the codepoints in the discarded font subset and the set of code points
+the the previous request was trying to add.</p>
    </ol>
    <h3 class="heading settled" data-level="2.3" id="server"><span class="secno">2.3. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="handling-requests"><span class="secno">2.3.1. </span><span class="content">Handling Requests</span><a class="self-link" href="#handling-requests"></a></h4>
@@ -1120,7 +1074,8 @@ If the server still has access</p>
  version and the server still has the previous</p>
    </ul>
    <p>If there is a mismatch the server should respond with
-a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a> the client should resend their <a href="#patch-request">§ 2.2.3 Patch Font Request</a> using the new code point reordering.</p>
+a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a> the client should resend their
+#patch-request (TODO) using the new code point reordering.</p>
    <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.</p>
    <h4 class="heading settled" data-level="2.3.5" id="client-font-mismatch"><span class="secno">2.3.5. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h4>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="21ccb7ae8d3198288cbfbf0dd8f7a8e0b27394ca" name="document-revision">
+  <meta content="be7bd2c2f25ae03ca6169db107bd8fc7cf4278b1" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-10">10 May 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-11">11 May 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -481,24 +481,22 @@ dfn > a.self-link::before      { content: "#"; }
       <li>
        <a href="#server"><span class="secno">2.3</span> <span class="content">Server</span></a>
        <ol class="toc">
-        <li><a href="#handling-rebase-request"><span class="secno">2.3.1</span> <span class="content">Handling New Font Request</span></a>
+        <li><a href="#handling-requests"><span class="secno">2.3.1</span> <span class="content">Handling Requests</span></a>
+        <li><a href="#handling-rebase-request"><span class="secno">2.3.2</span> <span class="content">Handling New Font Request</span></a>
+        <li><a href="#handling-patch-request"><span class="secno">2.3.3</span> <span class="content">Handling Patch Font Request</span></a>
+        <li><a href="#client-font-mismatch"><span class="secno">2.3.4</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
+        <li><a href="#client-base-mismatch"><span class="secno">2.3.5</span> <span class="content">Client’s Base does not Match Server’s</span></a>
+        <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.6</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
+        <li><a href="#subsetting-failures"><span class="secno">2.3.7</span> <span class="content">Subsetting Failures</span></a>
+        <li><a href="#rebase-response"><span class="secno">2.3.8</span> <span class="content">New Font Response</span></a>
+        <li><a href="#patch-response"><span class="secno">2.3.9</span> <span class="content">Patch Font Response</span></a>
+        <li><a href="#reindex-response"><span class="secno">2.3.10</span> <span class="content">Update Codepoint Ordering Response</span></a>
         <li>
-         <a href="#handling-patch-request"><span class="secno">2.3.2</span> <span class="content">Handling Patch Font Request</span></a>
+         <a href="#error-response"><span class="secno">2.3.11</span> <span class="content">Error Response</span></a>
          <ol class="toc">
-          <li><a href="#client-font-mismatch"><span class="secno">2.3.2.1</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
-          <li><a href="#client-base-mismatch"><span class="secno">2.3.2.2</span> <span class="content">Client’s Base does not Match Server’s</span></a>
-          <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.2.3</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
-          <li><a href="#subsetting-failures"><span class="secno">2.3.2.4</span> <span class="content">Subsetting Failures</span></a>
-         </ol>
-        <li><a href="#rebase-response"><span class="secno">2.3.3</span> <span class="content">New Font Response</span></a>
-        <li><a href="#patch-response"><span class="secno">2.3.4</span> <span class="content">Patch Font Response</span></a>
-        <li><a href="#reindex-response"><span class="secno">2.3.5</span> <span class="content">Update Codepoint Ordering Response</span></a>
-        <li>
-         <a href="#error-response"><span class="secno">2.3.6</span> <span class="content">Error Response</span></a>
-         <ol class="toc">
-          <li><a href="#error-font-not-found"><span class="secno">2.3.6.1</span> <span class="content">Font Not Found</span></a>
-          <li><a href="#error-bad-request"><span class="secno">2.3.6.2</span> <span class="content">Bad Request</span></a>
-          <li><a href="#error-internal-error"><span class="secno">2.3.6.3</span> <span class="content">Internal Error</span></a>
+          <li><a href="#error-font-not-found"><span class="secno">2.3.11.1</span> <span class="content">Font Not Found</span></a>
+          <li><a href="#error-bad-request"><span class="secno">2.3.11.2</span> <span class="content">Bad Request</span></a>
+          <li><a href="#error-internal-error"><span class="secno">2.3.11.3</span> <span class="content">Internal Error</span></a>
          </ol>
        </ol>
       <li>
@@ -506,7 +504,7 @@ dfn > a.self-link::before      { content: "#"; }
        <ol class="toc">
         <li><a href="#computing-checksums"><span class="secno">2.4.1</span> <span class="content">Computing Checksums</span></a>
         <li>
-         <a href="#codepoint-reordering"><span class="secno">2.4.2</span> <span class="content">Codepoint Reodering</span></a>
+         <a href="#codepoint-reordering"><span class="secno">2.4.2</span> <span class="content">Codepoint Reordering</span></a>
          <ol class="toc">
           <li><a href="#reordering-checksum"><span class="secno">2.4.2.1</span> <span class="content">Computing Checksum</span></a>
           <li><a href="#reordering-algorithm"><span class="secno">2.4.2.2</span> <span class="content">Recommended algorithm</span></a>
@@ -545,6 +543,7 @@ dfn > a.self-link::before      { content: "#"; }
    <p>See the Progressive Font Enrichment: Evaluation Report <a data-link-type="biblio" href="#biblio-pfe-report">[PFE-report]</a> for the investigation which led to this specification.</p>
    <h2 class="heading settled" data-level="2" id="patch-incxfer"><span class="secno">2. </span><span class="content">Patch Based Incremental Transfer</span><a class="self-link" href="#patch-incxfer"></a></h2>
    <p>TODO(garretrieger): Describe the high level version of how this version operates.</p>
+   <p>TODO(garretrieger): Describe font subsetting.</p>
    <h3 class="heading settled" data-level="2.1" id="data-types"><span class="secno">2.1. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
    <p>This section lists all of the data types that are used to form the request and response messages
 sent between the client and server.</p>
@@ -902,7 +901,7 @@ incrementally transferred.</p>
      <p>Original font checksum: the most recent value of <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
 from the server for this font.</p>
     <li data-md>
-     <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> received from the server
+     <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> received from the server
 for this font.</p>
     <li data-md>
      <p>Codepoint Reordering Checksum: The most recent <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> for this font.</p>
@@ -953,10 +952,10 @@ font the client should set:</p>
 response from the server for this particular font.</p>
     <li data-md>
      <p><a href="#PatchRequest"><code>PatchRequest.indices_have</code></a>:<br> Encodes the set of codepoints that are covered by the client’s current copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> to each codepoint value.</p>
+The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value.</p>
     <li data-md>
      <p><a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a>:<br> Encodes the set of codepoints that the clients would like added to it’s copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> to each codepoint value.</p>
+The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value.</p>
    </ul>
    <p>If the server has not previously provided a <code>codepoint_ordering</code> for this font then the <code>codepoints_have</code> and <code>codepoints_needed</code> fields should be used instead:</p>
    <ul>
@@ -1030,12 +1029,86 @@ do not match the checksums provided in a response from the server then the clien
      <p>Resend the request as a <a href="#rebase-request">§ 2.2.2 New Font Request</a> with the codepoints that are currently needed.</p>
    </ol>
    <h3 class="heading settled" data-level="2.3" id="server"><span class="secno">2.3. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
-   <p>TODO reorganize sections below here</p>
-   <h4 class="heading settled" data-level="2.3.1" id="handling-rebase-request"><span class="secno">2.3.1. </span><span class="content">Handling New Font Request</span><a class="self-link" href="#handling-rebase-request"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.3.2" id="handling-patch-request"><span class="secno">2.3.2. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.2.1" id="client-font-mismatch"><span class="secno">2.3.2.1. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h5>
+   <h4 class="heading settled" data-level="2.3.1" id="handling-requests"><span class="secno">2.3.1. </span><span class="content">Handling Requests</span><a class="self-link" href="#handling-requests"></a></h4>
+   <p>TODO(garretrieger):</p>
+   <ul>
+    <li data-md>
+     <p>url identifies the font being operated on ('the requested font')</p>
+    <li data-md>
+     <p>where to find the message.</p>
+    <li data-md>
+     <p>CBOR decoding</p>
+    <li data-md>
+     <p>Accepted http methods.</p>
+    <li data-md>
+     <p>Identify at least one patch format which all client/servers must support.</p>
+   </ul>
+   <h4 class="heading settled" data-level="2.3.2" id="handling-rebase-request"><span class="secno">2.3.2. </span><span class="content">Handling New Font Request</span><a class="self-link" href="#handling-rebase-request"></a></h4>
+   <p>If a request is received where:</p>
+   <ul>
+    <li data-md>
+     <p><a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> is a non-empty set,</p>
+    <li data-md>
+     <p><a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a> is not set or is an empty set,</p>
+    <li data-md>
+     <p>and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is not set or is an empty set;</p>
+   </ul>
+   <p>then the server must:</p>
+   <ol>
+    <li data-md>
+     <p>Generate a subset of the requested font that contains at least the code points
+in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
+   </ol>
+   <p>TODO(garretrieger): apply format encoding.</p>
+   <ol start="2">
+    <li data-md>
+     <p>Respond with a <a href="#rebase-response">§ 2.3.8 New Font Response</a>.</p>
+   </ol>
+   <h4 class="heading settled" data-level="2.3.3" id="handling-patch-request"><span class="secno">2.3.3. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <p>If a request is received where:</p>
+   <ul>
+    <li data-md>
+     <p>At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> and <a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a> is a non-empty set.</p>
+    <li data-md>
+     <p>At least one of <a href="#PatchRequest"><code>PatchRequest.codepoints_have</code></a> and <a href="#PatchRequest"><code>PatchRequest.indices_have</code></a> is a non-empty set.</p>
+   </ul>
+   <p>then the server must:</p>
+   <ol>
+    <li data-md>
+     <p>Determine the codepoint reordering of the requested font. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a>.</p>
+    <li data-md>
+     <p>Compute the codepoint <a href="#reordering-checksum">§ 2.4.2.1 Computing Checksum</a> of the reordering generated in step 1.
+ If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> this is a recoverable error, follow the procedure in <a href="#codepoint-reordering-mismatch">§ 2.3.6 Client Codepoint Reordering does not Match Servers</a>.</p>
+    <li data-md>
+     <p>Compute the checksum of the requested font. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a> this is a recoverable error, follow the procedure in <a href="#client-font-mismatch">§ 2.3.4 Client’s Original Font does not Match Server’s</a>.</p>
+    <li data-md>
+     <p>Transform the indices_have and indices_needed sets into codepoints by applying the codepoint
+ reordering from step 1.</p>
+    <li data-md>
+     <p>Union the transformed indices_have and codepoints_have sets to form the base codepoint set.</p>
+    <li data-md>
+     <p>Union the transformed indices_needed, codepoints_needed, and  base set to form the extended
+ codepoint set.</p>
+    <li data-md>
+     <p>Generate:</p>
+     <ul>
+      <li data-md>
+       <p>The base font subset, by subsetting the requested font to exactly thecodepoints in the base
+ set.</p>
+      <li data-md>
+       <p>The extended font subset, by subsetting the requested font to at least the codepoints in the
+ extended set.</p>
+     </ul>
+    <li data-md>
+     <p>Compute the checksum of the base font subset. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> this is a recoverable
+ error, follow the procedure in <a href="#client-base-mismatch">§ 2.3.5 Client’s Base does not Match Server’s</a>.</p>
+    <li data-md>
+     <p>Generate a binary difference between the extended font subset and the base font subset using
+ one of the patch formats listed in <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.</p>
+    <li data-md>
+     <p>Respond with a <a href="#patch-response">§ 2.3.9 Patch Font Response</a>.</p>
+   </ol>
+   <h4 class="heading settled" data-level="2.3.4" id="client-font-mismatch"><span class="secno">2.3.4. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h4>
    <p>Over time servers may upgrade the original copies of a font with newer
 versions. After such an upgrade, clients who have subsets built from the
 previous versions may contact the server and request a patch against the
@@ -1047,30 +1120,30 @@ the current version of the font. If a mismatch is detected there are two possibl
      <p>Patch client to the new font. This is possible if the server has access to the font files for
 previous versions of the font, and the provided checksum matches a previous version. The server
 may then compute a patch between the old version of the font and the new version of the font with
-any additional codepoints requested by the client. In this case the server should respond with a <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The response should set <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> to the checksum of
+any additional codepoints requested by the client. In this case the server should respond with a <a href="#patch-response">§ 2.3.9 Patch Font Response</a>. The response should set <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> to the checksum of
 the new version of the original font. Additionally it may be necessary to send a new codepoint
 ordering if the set of codepoints covered by the original font has changed.</p>
     <li data-md>
      <p>Replace the clients copy of the font. If the server is unable to match the provided checksum to any
-version of the font it has, then a <a href="#rebase-response">§ 2.3.3 New Font Response</a> should be sent instead which will instruct
+version of the font it has, then a <a href="#rebase-response">§ 2.3.8 New Font Response</a> should be sent instead which will instruct
 the client to replace the version they have with the newer version. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    </ul>
-   <h5 class="heading settled" data-level="2.3.2.2" id="client-base-mismatch"><span class="secno">2.3.2.2. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h5>
+   <h4 class="heading settled" data-level="2.3.5" id="client-base-mismatch"><span class="secno">2.3.5. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h4>
    <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
 the base font that a server computes not matching the base font that a client has. This case can be
 detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
-with a <a href="#rebase-response">§ 2.3.3 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The replacement font must cover
+with a <a href="#rebase-response">§ 2.3.8 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.9 Patch Font Response</a>. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
-   <h5 class="heading settled" data-level="2.3.2.3" id="codepoint-reordering-mismatch"><span class="secno">2.3.2.3. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h5>
+   <h4 class="heading settled" data-level="2.3.6" id="codepoint-reordering-mismatch"><span class="secno">2.3.6. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h4>
    <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
 detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
 checksum of the server’s codepoint reordering. If there is a mismatch the server should respond with
-a <a href="#reindex-response">§ 2.3.5 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.5 Update Codepoint Ordering Response</a> the client should resend their <a href="#patch-request">§ 2.2.3 Patch Font Request</a> using the new code point reordering.</p>
+a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a> the client should resend their <a href="#patch-request">§ 2.2.3 Patch Font Request</a> using the new code point reordering.</p>
    <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.</p>
-   <h5 class="heading settled" data-level="2.3.2.4" id="subsetting-failures"><span class="secno">2.3.2.4. </span><span class="content">Subsetting Failures</span><a class="self-link" href="#subsetting-failures"></a></h5>
-   <h4 class="heading settled" data-level="2.3.3" id="rebase-response"><span class="secno">2.3.3. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.7" id="subsetting-failures"><span class="secno">2.3.7. </span><span class="content">Subsetting Failures</span><a class="self-link" href="#subsetting-failures"></a></h4>
+   <h4 class="heading settled" data-level="2.3.8" id="rebase-response"><span class="secno">2.3.8. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h4>
    <p>TODO(garretrieger): update wording here to match new organization.</p>
    <p>If the client asks for a new font the server will respond with a single <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via COBR:</p>
    <ul>
@@ -1079,7 +1152,8 @@ the other recoverable error scenarios.</p>
     <li data-md>
      <p><a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>:<br> The checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) computed for the full unmodified original font.</p>
     <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>:<br> The compression format used to encode <a href="#PatchResponse"><code>PatchResponse.patch</code></a>.</p>
+     <p><a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>:<br> The compression format used to encode <a href="#PatchResponse"><code>PatchResponse.patch</code></a>.
+TODO(garretrieger): needs to be one of the formats specified by the client.</p>
     <li data-md>
      <p><a href="#PatchResponse"><code>PatchResponse.patch</code></a>:<br> A subset of the original font that contains data for at least the codepoints requested by the
 client in the <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a> field. The
@@ -1090,7 +1164,7 @@ may be needed for future content. The font subset is compressed by the format sp
 prior to compression.</p>
     <li data-md>
      <p><a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>:<br> The server should provide a codepoint reordering which the client will use to
-communicate codepoint sets back to the server. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> for details. The
+communicate codepoint sets back to the server. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> for details. The
 server is free to chose the mapping, but the mapping must use only code points in
 the original font and must map all codepoints in the original font.</p>
     <li data-md>
@@ -1099,22 +1173,22 @@ the original font and must map all codepoints in the original font.</p>
    <p>If the client receives a new font response it should replace any version of the font it currently has
 with the decompressed contents of the <a href="#PatchResponse"><code>PatchResponse.patch</code></a> Also <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>, <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>, and <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering_checksum</code></a> should be saved as
 they are needed for future requests.</p>
-   <h4 class="heading settled" data-level="2.3.4" id="patch-response"><span class="secno">2.3.4. </span><span class="content">Patch Font Response</span><a class="self-link" href="#patch-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.9" id="patch-response"><span class="secno">2.3.9. </span><span class="content">Patch Font Response</span><a class="self-link" href="#patch-response"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.3.5" id="reindex-response"><span class="secno">2.3.5. </span><span class="content">Update Codepoint Ordering Response</span><a class="self-link" href="#reindex-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.10" id="reindex-response"><span class="secno">2.3.10. </span><span class="content">Update Codepoint Ordering Response</span><a class="self-link" href="#reindex-response"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.3.6" id="error-response"><span class="secno">2.3.6. </span><span class="content">Error Response</span><a class="self-link" href="#error-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.11" id="error-response"><span class="secno">2.3.11. </span><span class="content">Error Response</span><a class="self-link" href="#error-response"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.6.1" id="error-font-not-found"><span class="secno">2.3.6.1. </span><span class="content">Font Not Found</span><a class="self-link" href="#error-font-not-found"></a></h5>
+   <h5 class="heading settled" data-level="2.3.11.1" id="error-font-not-found"><span class="secno">2.3.11.1. </span><span class="content">Font Not Found</span><a class="self-link" href="#error-font-not-found"></a></h5>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.6.2" id="error-bad-request"><span class="secno">2.3.6.2. </span><span class="content">Bad Request</span><a class="self-link" href="#error-bad-request"></a></h5>
+   <h5 class="heading settled" data-level="2.3.11.2" id="error-bad-request"><span class="secno">2.3.11.2. </span><span class="content">Bad Request</span><a class="self-link" href="#error-bad-request"></a></h5>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.6.3" id="error-internal-error"><span class="secno">2.3.6.3. </span><span class="content">Internal Error</span><a class="self-link" href="#error-internal-error"></a></h5>
+   <h5 class="heading settled" data-level="2.3.11.3" id="error-internal-error"><span class="secno">2.3.11.3. </span><span class="content">Internal Error</span><a class="self-link" href="#error-internal-error"></a></h5>
    <p>TODO(garretrieger): write this.</p>
    <h3 class="heading settled" data-level="2.4" id="procedures"><span class="secno">2.4. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
    <h4 class="heading settled" data-level="2.4.1" id="computing-checksums"><span class="secno">2.4.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.4.2" id="codepoint-reordering"><span class="secno">2.4.2. </span><span class="content">Codepoint Reodering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
+   <h4 class="heading settled" data-level="2.4.2" id="codepoint-reordering"><span class="secno">2.4.2. </span><span class="content">Codepoint Reordering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
    <p>TODO(garretrieger): write this.</p>
    <h5 class="heading settled" data-level="2.4.2.1" id="reordering-checksum"><span class="secno">2.4.2.1. </span><span class="content">Computing Checksum</span><a class="self-link" href="#reordering-checksum"></a></h5>
    <p>TODO(garretrieger): write this.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="e25e3c8631318a5b209d240c16b3e4046e9ada01" name="document-revision">
+  <meta content="6ebf275627bfa960df0fe5253a15120921ff3c42" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -463,50 +463,58 @@ dfn > a.self-link::before      { content: "#"; }
          </ol>
        </ol>
       <li>
-       <a href="#rebase-request"><span class="secno">2.2</span> <span class="content">New Font Request</span></a>
+       <a href="#client"><span class="secno">2.2</span> <span class="content">Client</span></a>
        <ol class="toc">
-        <li><a href="#rebase-request-post"><span class="secno">2.2.1</span> <span class="content">POST</span></a>
-        <li><a href="#rebase-request-get"><span class="secno">2.2.2</span> <span class="content">GET</span></a>
-        <li><a href="#rebase-standard-response"><span class="secno">2.2.3</span> <span class="content">Standard Response</span></a>
-        <li><a href="#rebase-errors"><span class="secno">2.2.4</span> <span class="content">Errors</span></a>
+        <li><a href="#client-state"><span class="secno">2.2.1</span> <span class="content">Client State</span></a>
+        <li>
+         <a href="#rebase-request"><span class="secno">2.2.2</span> <span class="content">New Font Request</span></a>
+         <ol class="toc">
+          <li><a href="#rebase-request-post"><span class="secno">2.2.2.1</span> <span class="content">POST</span></a>
+          <li><a href="#rebase-request-get"><span class="secno">2.2.2.2</span> <span class="content">GET</span></a>
+         </ol>
+        <li><a href="#patch-request"><span class="secno">2.2.3</span> <span class="content">Patch Font Request</span></a>
+        <li><a href="#handling-rebase-response"><span class="secno">2.2.4</span> <span class="content">Handling New Font Response</span></a>
+        <li>
+         <a href="#handling-patch-response"><span class="secno">2.2.5</span> <span class="content">Handling Patch Font Response</span></a>
+         <ol class="toc">
+          <li><a href="#patch-mismatch"><span class="secno">2.2.5.1</span> <span class="content">Client Side Patched Base Checksum Mismatch</span></a>
+         </ol>
+        <li><a href="#handling-reindex-response"><span class="secno">2.2.6</span> <span class="content">Handling Update Codepoint Ordering Response</span></a>
        </ol>
       <li>
-       <a href="#patch-request"><span class="secno">2.3</span> <span class="content">Patch Font Request</span></a>
+       <a href="#server"><span class="secno">2.3</span> <span class="content">Server</span></a>
        <ol class="toc">
-        <li><a href="#patch-standard-response"><span class="secno">2.3.1</span> <span class="content">Standard Response</span></a>
+        <li><a href="#handling-rebase-request"><span class="secno">2.3.1</span> <span class="content">Handling New Font Request</span></a>
         <li>
-         <a href="#patch-recoverable-errors"><span class="secno">2.3.2</span> <span class="content">Recoverable Errors</span></a>
+         <a href="#handling-patch-request"><span class="secno">2.3.2</span> <span class="content">Handling Patch Font Request</span></a>
          <ol class="toc">
           <li><a href="#client-font-mismatch"><span class="secno">2.3.2.1</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
           <li><a href="#client-base-mismatch"><span class="secno">2.3.2.2</span> <span class="content">Client’s Base does not Match Server’s</span></a>
           <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.2.3</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
-          <li><a href="#patch-mismatch"><span class="secno">2.3.2.4</span> <span class="content">Client Side Patched Base Checksum Mismatch</span></a>
-          <li><a href="#cmap4-overflow"><span class="secno">2.3.2.5</span> <span class="content">Cmap Format 4 Overflow</span></a>
-          <li><a href="#offset-overflow"><span class="secno">2.3.2.6</span> <span class="content">Offset Overflow during Subsetting</span></a>
+          <li><a href="#subsetting-failures"><span class="secno">2.3.2.4</span> <span class="content">Subsetting Failures</span></a>
          </ol>
-        <li><a href="#errors"><span class="secno">2.3.3</span> <span class="content">Errors</span></a>
-       </ol>
-      <li><a href="#rebase-response"><span class="secno">2.4</span> <span class="content">New Font Response</span></a>
-      <li><a href="#patch-response"><span class="secno">2.5</span> <span class="content">Patch Font Response</span></a>
-      <li><a href="#reindex-response"><span class="secno">2.6</span> <span class="content">Update Codepoint Ordering Response</span></a>
-      <li>
-       <a href="#error-response"><span class="secno">2.7</span> <span class="content">Error Response</span></a>
-       <ol class="toc">
-        <li><a href="#error-font-not-found"><span class="secno">2.7.1</span> <span class="content">Font Not Found</span></a>
-        <li><a href="#error-bad-request"><span class="secno">2.7.2</span> <span class="content">Bad Request</span></a>
-        <li><a href="#error-internal-error"><span class="secno">2.7.3</span> <span class="content">Internal Error</span></a>
-       </ol>
-      <li>
-       <a href="#procedures"><span class="secno">2.8</span> <span class="content">Procedures</span></a>
-       <ol class="toc">
-        <li><a href="#computing-checksums"><span class="secno">2.8.1</span> <span class="content">Computing Checksums</span></a>
+        <li><a href="#rebase-response"><span class="secno">2.3.3</span> <span class="content">New Font Response</span></a>
+        <li><a href="#patch-response"><span class="secno">2.3.4</span> <span class="content">Patch Font Response</span></a>
+        <li><a href="#reindex-response"><span class="secno">2.3.5</span> <span class="content">Update Codepoint Ordering Response</span></a>
         <li>
-         <a href="#codepoint-reordering"><span class="secno">2.8.2</span> <span class="content">Codepoint reodering</span></a>
+         <a href="#error-response"><span class="secno">2.3.6</span> <span class="content">Error Response</span></a>
          <ol class="toc">
-          <li><a href="#reordering-checksum"><span class="secno">2.8.2.1</span> <span class="content">Computing Checksum</span></a>
-          <li><a href="#reordering-algorithm"><span class="secno">2.8.2.2</span> <span class="content">Recommended algorithm</span></a>
+          <li><a href="#error-font-not-found"><span class="secno">2.3.6.1</span> <span class="content">Font Not Found</span></a>
+          <li><a href="#error-bad-request"><span class="secno">2.3.6.2</span> <span class="content">Bad Request</span></a>
+          <li><a href="#error-internal-error"><span class="secno">2.3.6.3</span> <span class="content">Internal Error</span></a>
          </ol>
-        <li><a href="#patch-formats"><span class="secno">2.8.3</span> <span class="content">Patch and Compression Formats</span></a>
+       </ol>
+      <li>
+       <a href="#procedures"><span class="secno">2.4</span> <span class="content">Procedures</span></a>
+       <ol class="toc">
+        <li><a href="#computing-checksums"><span class="secno">2.4.1</span> <span class="content">Computing Checksums</span></a>
+        <li>
+         <a href="#codepoint-reordering"><span class="secno">2.4.2</span> <span class="content">Codepoint reodering</span></a>
+         <ol class="toc">
+          <li><a href="#reordering-checksum"><span class="secno">2.4.2.1</span> <span class="content">Computing Checksum</span></a>
+          <li><a href="#reordering-algorithm"><span class="secno">2.4.2.2</span> <span class="content">Recommended algorithm</span></a>
+         </ol>
+        <li><a href="#patch-formats"><span class="secno">2.4.3</span> <span class="content">Patch and Compression Formats</span></a>
        </ol>
      </ol>
     <li><a href="#range-request-incxfer"><span class="secno">3</span> <span class="content">Range Request Incremental Transfer</span></a>
@@ -832,7 +840,7 @@ bit set and the list of ranges are unioned together.</p>
       <td>indices_needed
       <td>CompressedSet
    </table>
-   <p>patch_format can include be any of the values specified in <a href="#patch-formats">§ 2.8.3 Patch and Compression Formats</a>.</p>
+   <p>patch_format can include be any of the values specified in <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a>.</p>
    <h5 class="heading settled" data-level="2.1.5.4" id="PatchResponse"><span class="secno">2.1.5.4. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h5>
    <table>
     <tbody>
@@ -885,12 +893,15 @@ bit set and the list of ranges are unioned together.</p>
       <td>2
       <td>REINDEX
    </table>
-   <h3 class="heading settled" data-level="2.2" id="rebase-request"><span class="secno">2.2. </span><span class="content">New Font Request</span><a class="self-link" href="#rebase-request"></a></h3>
+   <h3 class="heading settled" data-level="2.2" id="client"><span class="secno">2.2. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
+   <h4 class="heading settled" data-level="2.2.1" id="client-state"><span class="secno">2.2.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
+   <p>TODO(garretrieger): document the state a client needs to maintain.</p>
+   <h4 class="heading settled" data-level="2.2.2" id="rebase-request"><span class="secno">2.2.2. </span><span class="content">New Font Request</span><a class="self-link" href="#rebase-request"></a></h4>
    <p>A new font request is sent by the client to get data for a font that it has not previously requested.
 In response the server will give the client a subset of the requested font that covers the codepoints
 listed in the request. A new font request is made via HTTP and may use either the GET or POST method.</p>
    <p>TODO(garretrieger): mention how the url identifies the specific font being requested.</p>
-   <h4 class="heading settled" data-level="2.2.1" id="rebase-request-post"><span class="secno">2.2.1. </span><span class="content">POST</span><a class="self-link" href="#rebase-request-post"></a></h4>
+   <h5 class="heading settled" data-level="2.2.2.1" id="rebase-request-post"><span class="secno">2.2.2.1. </span><span class="content">POST</span><a class="self-link" href="#rebase-request-post"></a></h5>
    <p>If sent as a POST request the post body will be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. All fields of <a href="#PatchRequest"><code>PatchRequest</code></a> should be left unset except for:</p>
    <ul>
     <li data-md>
@@ -900,26 +911,14 @@ unicode codepoints which the client requires data for.</p>
      <p><a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>:<br> This field should be populated with the set of <a href="#patch-formats">patch formats</a> that this
 client is capable of decoding. At least one format must be provided.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.2.2" id="rebase-request-get"><span class="secno">2.2.2. </span><span class="content">GET</span><a class="self-link" href="#rebase-request-get"></a></h4>
+   <h5 class="heading settled" data-level="2.2.2.2" id="rebase-request-get"><span class="secno">2.2.2.2. </span><span class="content">GET</span><a class="self-link" href="#rebase-request-get"></a></h5>
    <p>If sent as a GET request the client will include a single query parameter:</p>
    <ul>
     <li data-md>
      <p><code>request</code>:<br> The value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR
 and then base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>. The <a href="#PatchRequest"><code>PatchRequest</code></a> object uses the same fields as specified for a <a href="#rebase-request-post">POST</a> request.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.2.3" id="rebase-standard-response"><span class="secno">2.2.3. </span><span class="content">Standard Response</span><a class="self-link" href="#rebase-standard-response"></a></h4>
-   <p>The server will respond to a new font request with a <a href="#rebase-response">New Font Response</a>.</p>
-   <h4 class="heading settled" data-level="2.2.4" id="rebase-errors"><span class="secno">2.2.4. </span><span class="content">Errors</span><a class="self-link" href="#rebase-errors"></a></h4>
-   <p>The following errors may occur as a result of a new font request:</p>
-   <ul>
-    <li data-md>
-     <p><a href="#error-font-not-found">§ 2.7.1 Font Not Found</a></p>
-    <li data-md>
-     <p><a href="#error-bad-request">§ 2.7.2 Bad Request</a></p>
-    <li data-md>
-     <p><a href="#error-internal-error">§ 2.7.3 Internal Error</a></p>
-   </ul>
-   <h3 class="heading settled" data-level="2.3" id="patch-request"><span class="secno">2.3. </span><span class="content">Patch Font Request</span><a class="self-link" href="#patch-request"></a></h3>
+   <h4 class="heading settled" data-level="2.2.3" id="patch-request"><span class="secno">2.2.3. </span><span class="content">Patch Font Request</span><a class="self-link" href="#patch-request"></a></h4>
    <p>A patch font request is sent by a client to add data for additional codepoints to its font. Patch font
 requests are sent via HTTP and can only use the POST method. The request body is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR. The fields of
 should be set as follows:</p>
@@ -928,7 +927,7 @@ should be set as follows:</p>
      <p><a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>:<br> Set to the last saved value of original_font_checksum provided by a
 previous response from the server for this particular font.</p>
     <li data-md>
-     <p><a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a>:<br> Set to the checksum <a href="#computing-checksums">§ 2.8.1 Computing Checksums</a> of the client’s most recent
+     <p><a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a>:<br> Set to the checksum <a href="#computing-checksums">§ 2.4.1 Computing Checksums</a> of the client’s most recent
 copy of the font.</p>
     <li data-md>
      <p><a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>:<br> This field should be populated with the set of <a href="#patch-formats">patch formats</a> that this
@@ -942,10 +941,10 @@ font the client should set:</p>
 response from the server for this particular font.</p>
     <li data-md>
      <p><a href="#PatchRequest"><code>PatchRequest.indices_have</code></a>:<br> Encodes the set of codepoints that are covered by the client’s current copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.8.2 Codepoint reodering</a> to each codepoint value.</p>
+The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint reodering</a> to each codepoint value.</p>
     <li data-md>
      <p><a href="#PatchRequest"><code>PatchRequest.indices_needed</code></a>:<br> Encodes the set of codepoints that the clients would like added to it’s copy of the font.
-The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.8.2 Codepoint reodering</a> to each codepoint value.</p>
+The codepoint values are transformed to indices by applying <code>codepoint ordering</code> <a href="#codepoint-reordering">§ 2.4.2 Codepoint reodering</a> to each codepoint value.</p>
    </ul>
    <p>If the server has not previously provided a <code>codepoint_ordering</code> for this font then the <code>codepoints_have</code> and <code>codepoints_needed</code> fields should be used instead:</p>
    <ul>
@@ -955,9 +954,24 @@ The codepoint values are transformed to indices by applying <code>codepoint orde
      <p><a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>:<br> The set of codepoints that the clients would like added to it’s copy of
 the font.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.3.1" id="patch-standard-response"><span class="secno">2.3.1. </span><span class="content">Standard Response</span><a class="self-link" href="#patch-standard-response"></a></h4>
-   <p>The server will respond to a new font request with a <a href="#patch-response">Patch Font Response</a>.</p>
-   <h4 class="heading settled" data-level="2.3.2" id="patch-recoverable-errors"><span class="secno">2.3.2. </span><span class="content">Recoverable Errors</span><a class="self-link" href="#patch-recoverable-errors"></a></h4>
+   <h4 class="heading settled" data-level="2.2.4" id="handling-rebase-response"><span class="secno">2.2.4. </span><span class="content">Handling New Font Response</span><a class="self-link" href="#handling-rebase-response"></a></h4>
+   <p>TODO(garretrieger): write this. Include info on handling client side
+                    error scenarios (ie. checksum mismatches).</p>
+   <h4 class="heading settled" data-level="2.2.5" id="handling-patch-response"><span class="secno">2.2.5. </span><span class="content">Handling Patch Font Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <h5 class="heading settled" data-level="2.2.5.1" id="patch-mismatch"><span class="secno">2.2.5.1. </span><span class="content">Client Side Patched Base Checksum Mismatch</span><a class="self-link" href="#patch-mismatch"></a></h5>
+   <p>After a client receives a <a href="#patch-response">§ 2.3.4 Patch Font Response</a> and computes a new version of the font the client must
+compare the checksum <a href="#computing-checksums">§ 2.4.1 Computing Checksums</a> of the new font to <a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
+client must discard the response and should resend the request as a <a href="#rebase-request">§ 2.2.2 New Font Request</a>. Upon receiving
+a new copy of the font the client can replace any existing data it has for that font.</p>
+   <h4 class="heading settled" data-level="2.2.6" id="handling-reindex-response"><span class="secno">2.2.6. </span><span class="content">Handling Update Codepoint Ordering Response</span><a class="self-link" href="#handling-reindex-response"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <p>TODO reorganize sections below here</p>
+   <h3 class="heading settled" data-level="2.3" id="server"><span class="secno">2.3. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
+   <h4 class="heading settled" data-level="2.3.1" id="handling-rebase-request"><span class="secno">2.3.1. </span><span class="content">Handling New Font Request</span><a class="self-link" href="#handling-rebase-request"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <h4 class="heading settled" data-level="2.3.2" id="handling-patch-request"><span class="secno">2.3.2. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
    <h5 class="heading settled" data-level="2.3.2.1" id="client-font-mismatch"><span class="secno">2.3.2.1. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h5>
    <p>Over time servers may upgrade the original copies of a font with newer
 versions. After such an upgrade, clients who have subsets built from the
@@ -970,12 +984,12 @@ the current version of the font. If a mismatch is detected there are two possibl
      <p>Patch client to the new font. This is possible if the server has access to the font files for
 previous versions of the font, and the provided checksum matches a previous version. The server
 may then compute a patch between the old version of the font and the new version of the font with
-any additional codepoints requested by the client. In this case the server should respond with a <a href="#patch-response">§ 2.5 Patch Font Response</a>. The response should set <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> to the checksum of
+any additional codepoints requested by the client. In this case the server should respond with a <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The response should set <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> to the checksum of
 the new version of the original font. Additionally it may be necessary to send a new codepoint
 ordering if the set of codepoints covered by the original font has changed.</p>
     <li data-md>
      <p>Replace the clients copy of the font. If the server is unable to match the provided checksum to any
-version of the font it has, then a <a href="#rebase-response">§ 2.4 New Font Response</a> should be sent instead which will instruct
+version of the font it has, then a <a href="#rebase-response">§ 2.3.3 New Font Response</a> should be sent instead which will instruct
 the client to replace the version they have with the newer version. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    </ul>
@@ -983,40 +997,24 @@ at minimum the codepoints specified in the <code>codepoints_have/indices_have</c
    <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
 the base font that a server computes not matching the base font that a client has. This case can be
 detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
-with a <a href="#rebase-response">§ 2.4 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.5 Patch Font Response</a>. The replacement font must cover
+with a <a href="#rebase-response">§ 2.3.3 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    <h5 class="heading settled" data-level="2.3.2.3" id="codepoint-reordering-mismatch"><span class="secno">2.3.2.3. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h5>
    <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
 detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
 checksum of the server’s codepoint reordering. If there is a mismatch the server should respond with
-a <a href="#reindex-response">§ 2.6 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.6 Update Codepoint Ordering Response</a> the client should resend their <a href="#patch-request">§ 2.3 Patch Font Request</a> using the new code point reordering.</p>
+a <a href="#reindex-response">§ 2.3.5 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.5 Update Codepoint Ordering Response</a> the client should resend their <a href="#patch-request">§ 2.2.3 Patch Font Request</a> using the new code point reordering.</p>
    <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.</p>
-   <h5 class="heading settled" data-level="2.3.2.4" id="patch-mismatch"><span class="secno">2.3.2.4. </span><span class="content">Client Side Patched Base Checksum Mismatch</span><a class="self-link" href="#patch-mismatch"></a></h5>
-   <p>TODO(garretrieger): this belongs with info about client handling of the response</p>
-   <p>After a client receives a <a href="#patch-response">§ 2.5 Patch Font Response</a> and computes a new version of the font the client must
-compare the checksum <a href="#computing-checksums">§ 2.8.1 Computing Checksums</a> of the new font to <a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
-client must discard the response and should resend the request as a <a href="#rebase-request">§ 2.2 New Font Request</a>. Upon receiving
-a new copy of the font the client can replace any existing data it has for that font.</p>
-   <h5 class="heading settled" data-level="2.3.2.5" id="cmap4-overflow"><span class="secno">2.3.2.5. </span><span class="content">Cmap Format 4 Overflow</span><a class="self-link" href="#cmap4-overflow"></a></h5>
-   <h5 class="heading settled" data-level="2.3.2.6" id="offset-overflow"><span class="secno">2.3.2.6. </span><span class="content">Offset Overflow during Subsetting</span><a class="self-link" href="#offset-overflow"></a></h5>
-   <h4 class="heading settled" data-level="2.3.3" id="errors"><span class="secno">2.3.3. </span><span class="content">Errors</span><a class="self-link" href="#errors"></a></h4>
-   <p>The following errors may occur as a result of a patch font request:</p>
-   <ul>
-    <li data-md>
-     <p><a href="#error-font-not-found">§ 2.7.1 Font Not Found</a></p>
-    <li data-md>
-     <p><a href="#error-bad-request">§ 2.7.2 Bad Request</a></p>
-    <li data-md>
-     <p><a href="#error-internal-error">§ 2.7.3 Internal Error</a></p>
-   </ul>
-   <h3 class="heading settled" data-level="2.4" id="rebase-response"><span class="secno">2.4. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h3>
+   <h5 class="heading settled" data-level="2.3.2.4" id="subsetting-failures"><span class="secno">2.3.2.4. </span><span class="content">Subsetting Failures</span><a class="self-link" href="#subsetting-failures"></a></h5>
+   <h4 class="heading settled" data-level="2.3.3" id="rebase-response"><span class="secno">2.3.3. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h4>
+   <p>TODO(garretrieger): update wording here to match new organization.</p>
    <p>If the client asks for a new font the server will respond with a single <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via COBR:</p>
    <ul>
     <li data-md>
      <p><a href="#PatchResponse"><code>PatchResponse.response_type</code></a>:<br> is set to REBASE.</p>
     <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>:<br> The checksum (<a href="#computing-checksums">§ 2.8.1 Computing Checksums</a>) computed for the full unmodified original font.</p>
+     <p><a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>:<br> The checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) computed for the full unmodified original font.</p>
     <li data-md>
      <p><a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>:<br> The compression format used to encode <a href="#PatchResponse"><code>PatchResponse.patch</code></a>.</p>
     <li data-md>
@@ -1025,31 +1023,42 @@ client in the <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code
 server may opt to expand the subset requested by the client to include additional characters that
 may be needed for future content. The font subset is compressed by the format specified in <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a>.</p>
     <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a>:<br> The checksum (<a href="#computing-checksums">§ 2.8.1 Computing Checksums</a>) computed for the subsetted font,
+     <p><a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a>:<br> The checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) computed for the subsetted font,
 prior to compression.</p>
     <li data-md>
      <p><a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>:<br> The server should provide a codepoint reordering which the client will use to
-communicate codepoint sets back to the server. See <a href="#codepoint-reordering">§ 2.8.2 Codepoint reodering</a> for details. The
+communicate codepoint sets back to the server. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint reodering</a> for details. The
 server is free to chose the mapping, but the mapping must use only code points in
 the original font and must map all codepoints in the original font.</p>
     <li data-md>
-     <p><a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a>:<br> Checksum for the codepoint ordering <a href="#reordering-checksum">§ 2.8.2.1 Computing Checksum</a>.</p>
+     <p><a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a>:<br> Checksum for the codepoint ordering <a href="#reordering-checksum">§ 2.4.2.1 Computing Checksum</a>.</p>
    </ul>
    <p>If the client receives a new font response it should replace any version of the font it currently has
 with the decompressed contents of the <a href="#PatchResponse"><code>PatchResponse.patch</code></a> Also <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>, <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>, and <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering_checksum</code></a> should be saved as
 they are needed for future requests.</p>
-   <h3 class="heading settled" data-level="2.5" id="patch-response"><span class="secno">2.5. </span><span class="content">Patch Font Response</span><a class="self-link" href="#patch-response"></a></h3>
-   <h3 class="heading settled" data-level="2.6" id="reindex-response"><span class="secno">2.6. </span><span class="content">Update Codepoint Ordering Response</span><a class="self-link" href="#reindex-response"></a></h3>
-   <h3 class="heading settled" data-level="2.7" id="error-response"><span class="secno">2.7. </span><span class="content">Error Response</span><a class="self-link" href="#error-response"></a></h3>
-   <h4 class="heading settled" data-level="2.7.1" id="error-font-not-found"><span class="secno">2.7.1. </span><span class="content">Font Not Found</span><a class="self-link" href="#error-font-not-found"></a></h4>
-   <h4 class="heading settled" data-level="2.7.2" id="error-bad-request"><span class="secno">2.7.2. </span><span class="content">Bad Request</span><a class="self-link" href="#error-bad-request"></a></h4>
-   <h4 class="heading settled" data-level="2.7.3" id="error-internal-error"><span class="secno">2.7.3. </span><span class="content">Internal Error</span><a class="self-link" href="#error-internal-error"></a></h4>
-   <h3 class="heading settled" data-level="2.8" id="procedures"><span class="secno">2.8. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
-   <h4 class="heading settled" data-level="2.8.1" id="computing-checksums"><span class="secno">2.8.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
-   <h4 class="heading settled" data-level="2.8.2" id="codepoint-reordering"><span class="secno">2.8.2. </span><span class="content">Codepoint reodering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
-   <h5 class="heading settled" data-level="2.8.2.1" id="reordering-checksum"><span class="secno">2.8.2.1. </span><span class="content">Computing Checksum</span><a class="self-link" href="#reordering-checksum"></a></h5>
-   <h5 class="heading settled" data-level="2.8.2.2" id="reordering-algorithm"><span class="secno">2.8.2.2. </span><span class="content">Recommended algorithm</span><a class="self-link" href="#reordering-algorithm"></a></h5>
-   <h4 class="heading settled" data-level="2.8.3" id="patch-formats"><span class="secno">2.8.3. </span><span class="content">Patch and Compression Formats</span><a class="self-link" href="#patch-formats"></a></h4>
+   <h4 class="heading settled" data-level="2.3.4" id="patch-response"><span class="secno">2.3.4. </span><span class="content">Patch Font Response</span><a class="self-link" href="#patch-response"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <h4 class="heading settled" data-level="2.3.5" id="reindex-response"><span class="secno">2.3.5. </span><span class="content">Update Codepoint Ordering Response</span><a class="self-link" href="#reindex-response"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <h4 class="heading settled" data-level="2.3.6" id="error-response"><span class="secno">2.3.6. </span><span class="content">Error Response</span><a class="self-link" href="#error-response"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <h5 class="heading settled" data-level="2.3.6.1" id="error-font-not-found"><span class="secno">2.3.6.1. </span><span class="content">Font Not Found</span><a class="self-link" href="#error-font-not-found"></a></h5>
+   <p>TODO(garretrieger): write this.</p>
+   <h5 class="heading settled" data-level="2.3.6.2" id="error-bad-request"><span class="secno">2.3.6.2. </span><span class="content">Bad Request</span><a class="self-link" href="#error-bad-request"></a></h5>
+   <p>TODO(garretrieger): write this.</p>
+   <h5 class="heading settled" data-level="2.3.6.3" id="error-internal-error"><span class="secno">2.3.6.3. </span><span class="content">Internal Error</span><a class="self-link" href="#error-internal-error"></a></h5>
+   <p>TODO(garretrieger): write this.</p>
+   <h3 class="heading settled" data-level="2.4" id="procedures"><span class="secno">2.4. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
+   <h4 class="heading settled" data-level="2.4.1" id="computing-checksums"><span class="secno">2.4.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <h4 class="heading settled" data-level="2.4.2" id="codepoint-reordering"><span class="secno">2.4.2. </span><span class="content">Codepoint reodering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
+   <h5 class="heading settled" data-level="2.4.2.1" id="reordering-checksum"><span class="secno">2.4.2.1. </span><span class="content">Computing Checksum</span><a class="self-link" href="#reordering-checksum"></a></h5>
+   <p>TODO(garretrieger): write this.</p>
+   <h5 class="heading settled" data-level="2.4.2.2" id="reordering-algorithm"><span class="secno">2.4.2.2. </span><span class="content">Recommended algorithm</span><a class="self-link" href="#reordering-algorithm"></a></h5>
+   <p>TODO(garretrieger): write this.</p>
+   <h4 class="heading settled" data-level="2.4.3" id="patch-formats"><span class="secno">2.4.3. </span><span class="content">Patch and Compression Formats</span><a class="self-link" href="#patch-formats"></a></h4>
+   <p>TODO(garretrieger): write this.</p>
    <h2 class="heading settled" data-level="3" id="range-request-incxfer"><span class="secno">3. </span><span class="content">Range Request Incremental Transfer</span><a class="self-link" href="#range-request-incxfer"></a></h2>
    <h2 class="heading settled" data-level="4" id="negotiating-transfer-type"><span class="secno">4. </span><span class="content">Negotiating Incremental Transfer Type</span><a class="self-link" href="#negotiating-transfer-type"></a></h2>
    <h2 class="no-num heading settled" id="priv-sec"><span class="content">Privacy and Security Considerations</span><a class="self-link" href="#priv-sec"></a></h2>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="552c983b5cc8933a9a72ac1f79a5966314eea1db" name="document-revision">
+  <meta content="21ccb7ae8d3198288cbfbf0dd8f7a8e0b27394ca" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-07">7 May 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-10">10 May 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -485,8 +485,8 @@ dfn > a.self-link::before      { content: "#"; }
         <li>
          <a href="#handling-patch-request"><span class="secno">2.3.2</span> <span class="content">Handling Patch Font Request</span></a>
          <ol class="toc">
-          <li><a href="#client-base-mismatch"><span class="secno">2.3.2.1</span> <span class="content">Client’s Base does not Match Server’s</span></a>
-          <li><a href="#client-font-mismatch"><span class="secno">2.3.2.2</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
+          <li><a href="#client-font-mismatch"><span class="secno">2.3.2.1</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
+          <li><a href="#client-base-mismatch"><span class="secno">2.3.2.2</span> <span class="content">Client’s Base does not Match Server’s</span></a>
           <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.2.3</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
           <li><a href="#subsetting-failures"><span class="secno">2.3.2.4</span> <span class="content">Subsetting Failures</span></a>
          </ol>
@@ -899,11 +899,13 @@ transferred:</p>
      <p>Font subset: the binary data for the most recent version of the subset of the font being
 incrementally transferred.</p>
     <li data-md>
-     <p>Original font checksum: the most recent value of <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> received
+     <p>Original font checksum: the most recent value of <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
 from the server for this font.</p>
     <li data-md>
      <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reodering</a> received from the server
 for this font.</p>
+    <li data-md>
+     <p>Codepoint Reordering Checksum: The most recent <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> for this font.</p>
    </ul>
    <h4 class="heading settled" data-level="2.2.2" id="rebase-request"><span class="secno">2.2.2. </span><span class="content">New Font Request</span><a class="self-link" href="#rebase-request"></a></h4>
    <p>A new font request is sent by the client to begin incrementally transferring a font. The request
@@ -1006,7 +1008,18 @@ codepoint reordering map.</p>
  specified in the response.</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.6" id="handling-reindex-response"><span class="secno">2.2.6. </span><span class="content">Handling Update Codepoint Ordering Response</span><a class="self-link" href="#handling-reindex-response"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
+   <p>If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a> is equal to REINDEX, then the client must:</p>
+   <ol>
+    <li data-md>
+     <p>Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> matches the original font checksum stored in the clients state. If they do not match
+ this is a recoverable error, follow the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.7 Client Side Checksum Mismatch</a>.</p>
+    <li data-md>
+     <p>If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
+ then replace the codepoint ordering and checksum saved in the clients state with the new one
+ specified in the response.</p>
+    <li data-md>
+     <p>Resend the request which triggered this response using the new codepoint ordering.</p>
+   </ol>
    <h4 class="heading settled" data-level="2.2.7" id="client-side-checksum-mismatch"><span class="secno">2.2.7. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
    <p>If either the clients saved original font checksum or the checksum of the patched font subset
 do not match the checksums provided in a response from the server then the client should:</p>
@@ -1022,13 +1035,7 @@ do not match the checksums provided in a response from the server then the clien
    <p>TODO(garretrieger): write this.</p>
    <h4 class="heading settled" data-level="2.3.2" id="handling-patch-request"><span class="secno">2.3.2. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.2.1" id="client-base-mismatch"><span class="secno">2.3.2.1. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h5>
-   <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
-the base font that a server computes not matching the base font that a client has. This case can be
-detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
-with a <a href="#rebase-response">§ 2.3.3 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The replacement font must cover
-at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
-   <h5 class="heading settled" data-level="2.3.2.2" id="client-font-mismatch"><span class="secno">2.3.2.2. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h5>
+   <h5 class="heading settled" data-level="2.3.2.1" id="client-font-mismatch"><span class="secno">2.3.2.1. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h5>
    <p>Over time servers may upgrade the original copies of a font with newer
 versions. After such an upgrade, clients who have subsets built from the
 previous versions may contact the server and request a patch against the
@@ -1049,6 +1056,12 @@ version of the font it has, then a <a href="#rebase-response">§ 2.3.3 New Fon
 the client to replace the version they have with the newer version. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    </ul>
+   <h5 class="heading settled" data-level="2.3.2.2" id="client-base-mismatch"><span class="secno">2.3.2.2. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h5>
+   <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
+the base font that a server computes not matching the base font that a client has. This case can be
+detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
+with a <a href="#rebase-response">§ 2.3.3 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The replacement font must cover
+at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    <h5 class="heading settled" data-level="2.3.2.3" id="codepoint-reordering-mismatch"><span class="secno">2.3.2.3. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h5>
    <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
 detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="be7bd2c2f25ae03ca6169db107bd8fc7cf4278b1" name="document-revision">
+  <meta content="971fbaf0e28da93ce0b506148767af37bb347e0c" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -484,9 +484,9 @@ dfn > a.self-link::before      { content: "#"; }
         <li><a href="#handling-requests"><span class="secno">2.3.1</span> <span class="content">Handling Requests</span></a>
         <li><a href="#handling-rebase-request"><span class="secno">2.3.2</span> <span class="content">Handling New Font Request</span></a>
         <li><a href="#handling-patch-request"><span class="secno">2.3.3</span> <span class="content">Handling Patch Font Request</span></a>
-        <li><a href="#client-font-mismatch"><span class="secno">2.3.4</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
-        <li><a href="#client-base-mismatch"><span class="secno">2.3.5</span> <span class="content">Client’s Base does not Match Server’s</span></a>
-        <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.6</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
+        <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.4</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
+        <li><a href="#client-font-mismatch"><span class="secno">2.3.5</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
+        <li><a href="#client-base-mismatch"><span class="secno">2.3.6</span> <span class="content">Client’s Base does not Match Server’s</span></a>
         <li><a href="#subsetting-failures"><span class="secno">2.3.7</span> <span class="content">Subsetting Failures</span></a>
         <li><a href="#rebase-response"><span class="secno">2.3.8</span> <span class="content">New Font Response</span></a>
         <li><a href="#patch-response"><span class="secno">2.3.9</span> <span class="content">Patch Font Response</span></a>
@@ -1058,9 +1058,8 @@ do not match the checksums provided in a response from the server then the clien
     <li data-md>
      <p>Generate a subset of the requested font that contains at least the code points
 in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
-   </ol>
-   <p>TODO(garretrieger): apply format encoding.</p>
-   <ol start="2">
+    <li data-md>
+     <p>Encode the subset with one of the formats listed in <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.</p>
     <li data-md>
      <p>Respond with a <a href="#rebase-response">§ 2.3.8 New Font Response</a>.</p>
    </ol>
@@ -1078,9 +1077,9 @@ in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
      <p>Determine the codepoint reordering of the requested font. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a>.</p>
     <li data-md>
      <p>Compute the codepoint <a href="#reordering-checksum">§ 2.4.2.1 Computing Checksum</a> of the reordering generated in step 1.
- If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> this is a recoverable error, follow the procedure in <a href="#codepoint-reordering-mismatch">§ 2.3.6 Client Codepoint Reordering does not Match Servers</a>.</p>
+ If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> this is a recoverable error, follow the procedure in <a href="#codepoint-reordering-mismatch">§ 2.3.4 Client Codepoint Reordering does not Match Servers</a>.</p>
     <li data-md>
-     <p>Compute the checksum of the requested font. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a> this is a recoverable error, follow the procedure in <a href="#client-font-mismatch">§ 2.3.4 Client’s Original Font does not Match Server’s</a>.</p>
+     <p>Compute the checksum of the requested font. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a> this is a recoverable error, follow the procedure in <a href="#client-font-mismatch">§ 2.3.5 Client’s Original Font does not Match Server’s</a>.</p>
     <li data-md>
      <p>Transform the indices_have and indices_needed sets into codepoints by applying the codepoint
  reordering from step 1.</p>
@@ -1101,47 +1100,54 @@ in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
      </ul>
     <li data-md>
      <p>Compute the checksum of the base font subset. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> this is a recoverable
- error, follow the procedure in <a href="#client-base-mismatch">§ 2.3.5 Client’s Base does not Match Server’s</a>.</p>
+ error, follow the procedure in <a href="#client-base-mismatch">§ 2.3.6 Client’s Base does not Match Server’s</a>.</p>
     <li data-md>
      <p>Generate a binary difference between the extended font subset and the base font subset using
  one of the patch formats listed in <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.</p>
     <li data-md>
      <p>Respond with a <a href="#patch-response">§ 2.3.9 Patch Font Response</a>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.3.4" id="client-font-mismatch"><span class="secno">2.3.4. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h4>
+   <h4 class="heading settled" data-level="2.3.4" id="codepoint-reordering-mismatch"><span class="secno">2.3.4. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h4>
+   <p>TODO(garretrieger): case where codepoint reodering differs because of a upgraded original font.</p>
+   <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
+detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
+checksum of the server’s codepoint reordering. In some cases the mismatch is caused by the server
+having updated the requested font with a new version which in turn can change the reordering.
+If the server still has access</p>
+   <ul>
+    <li data-md>
+     <p>If the codepoint ordering has changed because the requested font has been updated with a newer
+ version and the server still has the previous</p>
+   </ul>
+   <p>If there is a mismatch the server should respond with
+a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a> the client should resend their <a href="#patch-request">§ 2.2.3 Patch Font Request</a> using the new code point reordering.</p>
+   <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
+the other recoverable error scenarios.</p>
+   <h4 class="heading settled" data-level="2.3.5" id="client-font-mismatch"><span class="secno">2.3.5. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h4>
    <p>Over time servers may upgrade the original copies of a font with newer
 versions. After such an upgrade, clients who have subsets built from the
 previous versions may contact the server and request a patch against the
 previous version of the font.</p>
-   <p>The server will detect this case by checking that <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> matches the checksum of
+   <p>The server can detect this case by checking that <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a> matches the checksum of
 the current version of the font. If a mismatch is detected there are two possible resolutions:</p>
    <ul>
     <li data-md>
      <p>Patch client to the new font. This is possible if the server has access to the font files for
-previous versions of the font, and the provided checksum matches a previous version. The server
-may then compute a patch between the old version of the font and the new version of the font with
-any additional codepoints requested by the client. In this case the server should respond with a <a href="#patch-response">§ 2.3.9 Patch Font Response</a>. The response should set <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> to the checksum of
-the new version of the original font. Additionally it may be necessary to send a new codepoint
-ordering if the set of codepoints covered by the original font has changed.</p>
+previous versions of the font, and the provided checksum matches a previous version. Follow
+the remaining steps in <a href="#handling-patch-request">§ 2.3.3 Handling Patch Font Request</a> but replace the font used to generate
+the base subset with the previous version that has a checksum matching <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>.</p>
     <li data-md>
      <p>Replace the clients copy of the font. If the server is unable to match the provided checksum to any
 version of the font it has, then a <a href="#rebase-response">§ 2.3.8 New Font Response</a> should be sent instead which will instruct
 the client to replace the version they have with the newer version. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.3.5" id="client-base-mismatch"><span class="secno">2.3.5. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h4>
+   <h4 class="heading settled" data-level="2.3.6" id="client-base-mismatch"><span class="secno">2.3.6. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h4>
    <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
 the base font that a server computes not matching the base font that a client has. This case can be
 detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
 with a <a href="#rebase-response">§ 2.3.8 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.9 Patch Font Response</a>. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
-   <h4 class="heading settled" data-level="2.3.6" id="codepoint-reordering-mismatch"><span class="secno">2.3.6. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h4>
-   <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
-detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
-checksum of the server’s codepoint reordering. If there is a mismatch the server should respond with
-a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a> the client should resend their <a href="#patch-request">§ 2.2.3 Patch Font Request</a> using the new code point reordering.</p>
-   <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
-the other recoverable error scenarios.</p>
    <h4 class="heading settled" data-level="2.3.7" id="subsetting-failures"><span class="secno">2.3.7. </span><span class="content">Subsetting Failures</span><a class="self-link" href="#subsetting-failures"></a></h4>
    <h4 class="heading settled" data-level="2.3.8" id="rebase-response"><span class="secno">2.3.8. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h4>
    <p>TODO(garretrieger): update wording here to match new organization.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="9589728b22e2193405d001b8ae19ec641c8f0b7b" name="document-revision">
+  <meta content="80e476584636c4fad7a2e033d858d37683cea357" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -473,22 +473,25 @@ dfn > a.self-link::before      { content: "#"; }
       <li>
        <a href="#server"><span class="secno">2.3</span> <span class="content">Server</span></a>
        <ol class="toc">
-        <li><a href="#handling-requests"><span class="secno">2.3.1</span> <span class="content">Handling Requests</span></a>
-        <li><a href="#handling-rebase-request"><span class="secno">2.3.2</span> <span class="content">Handling New Font Request</span></a>
-        <li><a href="#handling-patch-request"><span class="secno">2.3.3</span> <span class="content">Handling Patch Font Request</span></a>
-        <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.4</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
-        <li><a href="#client-font-mismatch"><span class="secno">2.3.5</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
-        <li><a href="#client-base-mismatch"><span class="secno">2.3.6</span> <span class="content">Client’s Base does not Match Server’s</span></a>
-        <li><a href="#subsetting-failures"><span class="secno">2.3.7</span> <span class="content">Subsetting Failures</span></a>
-        <li><a href="#rebase-response"><span class="secno">2.3.8</span> <span class="content">New Font Response</span></a>
-        <li><a href="#patch-response"><span class="secno">2.3.9</span> <span class="content">Patch Font Response</span></a>
-        <li><a href="#reindex-response"><span class="secno">2.3.10</span> <span class="content">Update Codepoint Ordering Response</span></a>
+        <li><a href="#handling-patch-request"><span class="secno">2.3.1</span> <span class="content">Responding to PatchRequest’s</span></a>
+        <li><a href="#patch-response"><span class="secno">2.3.2</span> <span class="content">PatchResponse</span></a>
+        <li><a href="#error-responses"><span class="secno">2.3.3</span> <span class="content">Error Responses ###</span></a>
+        <li><a href="#handling-requests"><span class="secno">2.3.4</span> <span class="content">Handling Requests</span></a>
+        <li><a href="#handling-rebase-request"><span class="secno">2.3.5</span> <span class="content">Handling New Font Request</span></a>
+        <li><a href="#handling-patch-request①"><span class="secno">2.3.6</span> <span class="content">Handling Patch Font Request</span></a>
+        <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.7</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
+        <li><a href="#client-font-mismatch"><span class="secno">2.3.8</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
+        <li><a href="#client-base-mismatch"><span class="secno">2.3.9</span> <span class="content">Client’s Base does not Match Server’s</span></a>
+        <li><a href="#subsetting-failures"><span class="secno">2.3.10</span> <span class="content">Subsetting Failures</span></a>
+        <li><a href="#rebase-response"><span class="secno">2.3.11</span> <span class="content">New Font Response</span></a>
+        <li><a href="#patch-response①"><span class="secno">2.3.12</span> <span class="content">Patch Font Response</span></a>
+        <li><a href="#reindex-response"><span class="secno">2.3.13</span> <span class="content">Update Codepoint Ordering Response</span></a>
         <li>
-         <a href="#error-response"><span class="secno">2.3.11</span> <span class="content">Error Response</span></a>
+         <a href="#error-response"><span class="secno">2.3.14</span> <span class="content">Error Response</span></a>
          <ol class="toc">
-          <li><a href="#error-font-not-found"><span class="secno">2.3.11.1</span> <span class="content">Font Not Found</span></a>
-          <li><a href="#error-bad-request"><span class="secno">2.3.11.2</span> <span class="content">Bad Request</span></a>
-          <li><a href="#error-internal-error"><span class="secno">2.3.11.3</span> <span class="content">Internal Error</span></a>
+          <li><a href="#error-font-not-found"><span class="secno">2.3.14.1</span> <span class="content">Font Not Found</span></a>
+          <li><a href="#error-bad-request"><span class="secno">2.3.14.2</span> <span class="content">Bad Request</span></a>
+          <li><a href="#error-internal-error"><span class="secno">2.3.14.3</span> <span class="content">Internal Error</span></a>
          </ol>
        </ol>
       <li>
@@ -972,6 +975,7 @@ If neither <code>replacement</code> or <code>patch</code> are set, then the clie
 resend the request that triggered this response but use the new codepoint ordering provided in
 this response.</p>
    </ol>
+   <p>TODO(garretrieger): how to handle error status codes (ie. 4xx, 5xx).</p>
    <h4 class="heading settled" data-level="2.2.4" id="client-side-checksum-mismatch"><span class="secno">2.2.4. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
    <p>If the the checksum of the font subset computed by the client does not match the <code>patched_checksum</code> in the server’s response then the client should:</p>
    <ol>
@@ -983,7 +987,30 @@ to the union of the codepoints in the discarded font subset and the set of code 
 the the previous request was trying to add.</p>
    </ol>
    <h3 class="heading settled" data-level="2.3" id="server"><span class="secno">2.3. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
-   <h4 class="heading settled" data-level="2.3.1" id="handling-requests"><span class="secno">2.3.1. </span><span class="content">Handling Requests</span><a class="self-link" href="#handling-requests"></a></h4>
+   <h4 class="heading settled" data-level="2.3.1" id="handling-patch-request"><span class="secno">2.3.1. </span><span class="content">Responding to PatchRequest’s</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> that
+was populated according to the requirements in <a href="#extend-subset">§ 2.2.2 Extending the Font Subset</a> then it should respond with HTTP
+status code 200. The body of the response should be a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>
+   <p>TODO(garretrieger): describe producing two codepoint sets - codepoints needed, codepoints have
+TODO(garretrieger): say something about original font checksum? it doesn’t need to match...
+TODO(garretrieger): note the server should try and produce a patch instead of a replacement
+                    where possible.</p>
+   <p>The response object must:</p>
+   <ul>
+    <li data-md>
+     <p>when processed by the client according to <a href="#handling-patch-response">§ 2.2.3 Handling PatchResponse</a> result in a font subset
+that contains data for at least the union of the set of codepoints needed and the sets of
+codepoints the client already has. The format of the used patch in the response must be one of
+those listed in <code>accept_patch_format</code>.</p>
+    <li data-md>
+     <p>OR, ... TODO(garretrieger): alternately can respond just with an updated codepoint ordering.</p>
+   </ul>
+   <p>The fields should
+be set as follows</p>
+   <h4 class="heading settled" data-level="2.3.2" id="patch-response"><span class="secno">2.3.2. </span><span class="content">PatchResponse</span><a class="self-link" href="#patch-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.3" id="error-responses"><span class="secno">2.3.3. </span><span class="content">Error Responses ###</span><a class="self-link" href="#error-responses"></a></h4>
+   <p>///////////////// OLD</p>
+   <h4 class="heading settled" data-level="2.3.4" id="handling-requests"><span class="secno">2.3.4. </span><span class="content">Handling Requests</span><a class="self-link" href="#handling-requests"></a></h4>
    <p>TODO(garretrieger):</p>
    <ul>
     <li data-md>
@@ -997,7 +1024,7 @@ the the previous request was trying to add.</p>
     <li data-md>
      <p>Identify at least one patch format which all client/servers must support.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.3.2" id="handling-rebase-request"><span class="secno">2.3.2. </span><span class="content">Handling New Font Request</span><a class="self-link" href="#handling-rebase-request"></a></h4>
+   <h4 class="heading settled" data-level="2.3.5" id="handling-rebase-request"><span class="secno">2.3.5. </span><span class="content">Handling New Font Request</span><a class="self-link" href="#handling-rebase-request"></a></h4>
    <p>If a request is received where:</p>
    <ul>
     <li data-md>
@@ -1015,9 +1042,9 @@ in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
     <li data-md>
      <p>Encode the subset with one of the formats listed in <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.</p>
     <li data-md>
-     <p>Respond with a <a href="#rebase-response">§ 2.3.8 New Font Response</a>.</p>
+     <p>Respond with a <a href="#rebase-response">§ 2.3.11 New Font Response</a>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.3.3" id="handling-patch-request"><span class="secno">2.3.3. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <h4 class="heading settled" data-level="2.3.6" id="handling-patch-request①"><span class="secno">2.3.6. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request①"></a></h4>
    <p>If a request is received where:</p>
    <ul>
     <li data-md>
@@ -1031,9 +1058,9 @@ in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
      <p>Determine the codepoint reordering of the requested font. See <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a>.</p>
     <li data-md>
      <p>Compute the codepoint <a href="#reordering-checksum">§ 2.4.2.1 Computing Checksum</a> of the reordering generated in step 1.
- If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> this is a recoverable error, follow the procedure in <a href="#codepoint-reordering-mismatch">§ 2.3.4 Client Codepoint Reordering does not Match Servers</a>.</p>
+ If it is not equal to <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> this is a recoverable error, follow the procedure in <a href="#codepoint-reordering-mismatch">§ 2.3.7 Client Codepoint Reordering does not Match Servers</a>.</p>
     <li data-md>
-     <p>Compute the checksum of the requested font. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a> this is a recoverable error, follow the procedure in <a href="#client-font-mismatch">§ 2.3.5 Client’s Original Font does not Match Server’s</a>.</p>
+     <p>Compute the checksum of the requested font. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.original_font_checsum</code></a> this is a recoverable error, follow the procedure in <a href="#client-font-mismatch">§ 2.3.8 Client’s Original Font does not Match Server’s</a>.</p>
     <li data-md>
      <p>Transform the indices_have and indices_needed sets into codepoints by applying the codepoint
  reordering from step 1.</p>
@@ -1054,14 +1081,14 @@ in <a href="#PatchRequest"><code>PatchRequest.codepoints_needed</code></a>.</p>
      </ul>
     <li data-md>
      <p>Compute the checksum of the base font subset. If it is not equal to <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> this is a recoverable
- error, follow the procedure in <a href="#client-base-mismatch">§ 2.3.6 Client’s Base does not Match Server’s</a>.</p>
+ error, follow the procedure in <a href="#client-base-mismatch">§ 2.3.9 Client’s Base does not Match Server’s</a>.</p>
     <li data-md>
      <p>Generate a binary difference between the extended font subset and the base font subset using
  one of the patch formats listed in <a href="#PatchRequest"><code>PatchRequest.patch_format</code></a>.</p>
     <li data-md>
-     <p>Respond with a <a href="#patch-response">§ 2.3.9 Patch Font Response</a>.</p>
+     <p>Respond with a <a href="#patch-response">§ 2.3.2 PatchResponse</a>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.3.4" id="codepoint-reordering-mismatch"><span class="secno">2.3.4. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h4>
+   <h4 class="heading settled" data-level="2.3.7" id="codepoint-reordering-mismatch"><span class="secno">2.3.7. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h4>
    <p>TODO(garretrieger): case where codepoint reodering differs because of a upgraded original font.</p>
    <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
 detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a
@@ -1074,11 +1101,11 @@ If the server still has access</p>
  version and the server still has the previous</p>
    </ul>
    <p>If there is a mismatch the server should respond with
-a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.10 Update Codepoint Ordering Response</a> the client should resend their
+a <a href="#reindex-response">§ 2.3.13 Update Codepoint Ordering Response</a>. After receiving a <a href="#reindex-response">§ 2.3.13 Update Codepoint Ordering Response</a> the client should resend their
 #patch-request (TODO) using the new code point reordering.</p>
    <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.</p>
-   <h4 class="heading settled" data-level="2.3.5" id="client-font-mismatch"><span class="secno">2.3.5. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h4>
+   <h4 class="heading settled" data-level="2.3.8" id="client-font-mismatch"><span class="secno">2.3.8. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h4>
    <p>Over time servers may upgrade the original copies of a font with newer
 versions. After such an upgrade, clients who have subsets built from the
 previous versions may contact the server and request a patch against the
@@ -1089,22 +1116,22 @@ the current version of the font. If a mismatch is detected there are two possibl
     <li data-md>
      <p>Patch client to the new font. This is possible if the server has access to the font files for
 previous versions of the font, and the provided checksum matches a previous version. Follow
-the remaining steps in <a href="#handling-patch-request">§ 2.3.3 Handling Patch Font Request</a> but replace the font used to generate
+the remaining steps in <a href="#handling-patch-request">§ 2.3.1 Responding to PatchRequest’s</a> but replace the font used to generate
 the base subset with the previous version that has a checksum matching <a href="#PatchRequest"><code>PatchRequest.original_font_checksum</code></a>.</p>
     <li data-md>
      <p>Replace the clients copy of the font. If the server is unable to match the provided checksum to any
-version of the font it has, then a <a href="#rebase-response">§ 2.3.8 New Font Response</a> should be sent instead which will instruct
+version of the font it has, then a <a href="#rebase-response">§ 2.3.11 New Font Response</a> should be sent instead which will instruct
 the client to replace the version they have with the newer version. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.3.6" id="client-base-mismatch"><span class="secno">2.3.6. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h4>
+   <h4 class="heading settled" data-level="2.3.9" id="client-base-mismatch"><span class="secno">2.3.9. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h4>
    <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
 the base font that a server computes not matching the base font that a client has. This case can be
 detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
-with a <a href="#rebase-response">§ 2.3.8 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.9 Patch Font Response</a>. The replacement font must cover
+with a <a href="#rebase-response">§ 2.3.11 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.2 PatchResponse</a>. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
-   <h4 class="heading settled" data-level="2.3.7" id="subsetting-failures"><span class="secno">2.3.7. </span><span class="content">Subsetting Failures</span><a class="self-link" href="#subsetting-failures"></a></h4>
-   <h4 class="heading settled" data-level="2.3.8" id="rebase-response"><span class="secno">2.3.8. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.10" id="subsetting-failures"><span class="secno">2.3.10. </span><span class="content">Subsetting Failures</span><a class="self-link" href="#subsetting-failures"></a></h4>
+   <h4 class="heading settled" data-level="2.3.11" id="rebase-response"><span class="secno">2.3.11. </span><span class="content">New Font Response</span><a class="self-link" href="#rebase-response"></a></h4>
    <p>TODO(garretrieger): update wording here to match new organization.</p>
    <p>If the client asks for a new font the server will respond with a single <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via COBR:</p>
    <ul>
@@ -1134,17 +1161,17 @@ the original font and must map all codepoints in the original font.</p>
    <p>If the client receives a new font response it should replace any version of the font it currently has
 with the decompressed contents of the <a href="#PatchResponse"><code>PatchResponse.patch</code></a> Also <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a>, <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a>, and <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering_checksum</code></a> should be saved as
 they are needed for future requests.</p>
-   <h4 class="heading settled" data-level="2.3.9" id="patch-response"><span class="secno">2.3.9. </span><span class="content">Patch Font Response</span><a class="self-link" href="#patch-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.12" id="patch-response①"><span class="secno">2.3.12. </span><span class="content">Patch Font Response</span><a class="self-link" href="#patch-response①"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.3.10" id="reindex-response"><span class="secno">2.3.10. </span><span class="content">Update Codepoint Ordering Response</span><a class="self-link" href="#reindex-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.13" id="reindex-response"><span class="secno">2.3.13. </span><span class="content">Update Codepoint Ordering Response</span><a class="self-link" href="#reindex-response"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.3.11" id="error-response"><span class="secno">2.3.11. </span><span class="content">Error Response</span><a class="self-link" href="#error-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.14" id="error-response"><span class="secno">2.3.14. </span><span class="content">Error Response</span><a class="self-link" href="#error-response"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.11.1" id="error-font-not-found"><span class="secno">2.3.11.1. </span><span class="content">Font Not Found</span><a class="self-link" href="#error-font-not-found"></a></h5>
+   <h5 class="heading settled" data-level="2.3.14.1" id="error-font-not-found"><span class="secno">2.3.14.1. </span><span class="content">Font Not Found</span><a class="self-link" href="#error-font-not-found"></a></h5>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.11.2" id="error-bad-request"><span class="secno">2.3.11.2. </span><span class="content">Bad Request</span><a class="self-link" href="#error-bad-request"></a></h5>
+   <h5 class="heading settled" data-level="2.3.14.2" id="error-bad-request"><span class="secno">2.3.14.2. </span><span class="content">Bad Request</span><a class="self-link" href="#error-bad-request"></a></h5>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.11.3" id="error-internal-error"><span class="secno">2.3.11.3. </span><span class="content">Internal Error</span><a class="self-link" href="#error-internal-error"></a></h5>
+   <h5 class="heading settled" data-level="2.3.14.3" id="error-internal-error"><span class="secno">2.3.14.3. </span><span class="content">Internal Error</span><a class="self-link" href="#error-internal-error"></a></h5>
    <p>TODO(garretrieger): write this.</p>
    <h3 class="heading settled" data-level="2.4" id="procedures"><span class="secno">2.4. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
    <h4 class="heading settled" data-level="2.4.1" id="computing-checksums"><span class="secno">2.4.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="2b9b80275cb30206d1d9084bad9c6d06c4ac40a2" name="document-revision">
+  <meta content="e25e3c8631318a5b209d240c16b3e4046e9ada01" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -908,7 +908,7 @@ client is capable of decoding. At least one format must be provided.</p>
 and then base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>. The <a href="#PatchRequest"><code>PatchRequest</code></a> object uses the same fields as specified for a <a href="#rebase-request-post">POST</a> request.</p>
    </ul>
    <h4 class="heading settled" data-level="2.2.3" id="rebase-standard-response"><span class="secno">2.2.3. </span><span class="content">Standard Response</span><a class="self-link" href="#rebase-standard-response"></a></h4>
-   <p>The server will response to a new font request with a <a href="#rebase-response">New Font Response</a>.</p>
+   <p>The server will respond to a new font request with a <a href="#rebase-response">New Font Response</a>.</p>
    <h4 class="heading settled" data-level="2.2.4" id="rebase-errors"><span class="secno">2.2.4. </span><span class="content">Errors</span><a class="self-link" href="#rebase-errors"></a></h4>
    <p>The following errors may occur as a result of a new font request:</p>
    <ul>
@@ -956,7 +956,7 @@ The codepoint values are transformed to indices by applying <code>codepoint orde
 the font.</p>
    </ul>
    <h4 class="heading settled" data-level="2.3.1" id="patch-standard-response"><span class="secno">2.3.1. </span><span class="content">Standard Response</span><a class="self-link" href="#patch-standard-response"></a></h4>
-   <p>The server will response to a new font request with a <a href="#patch-response">Patch Font Response</a>.</p>
+   <p>The server will respond to a new font request with a <a href="#patch-response">Patch Font Response</a>.</p>
    <h4 class="heading settled" data-level="2.3.2" id="patch-recoverable-errors"><span class="secno">2.3.2. </span><span class="content">Recoverable Errors</span><a class="self-link" href="#patch-recoverable-errors"></a></h4>
    <h5 class="heading settled" data-level="2.3.2.1" id="client-font-mismatch"><span class="secno">2.3.2.1. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h5>
    <p>Over time servers may upgrade the original copies of a font with newer
@@ -993,6 +993,11 @@ a <a href="#reindex-response">§ 2.6 Update Codepoint Ordering Response</a>. A
    <p>If a reordering mismatch is detected it must be resolved prior to attempting to resolve any of
 the other recoverable error scenarios.</p>
    <h5 class="heading settled" data-level="2.3.2.4" id="patch-mismatch"><span class="secno">2.3.2.4. </span><span class="content">Client Side Patched Base Checksum Mismatch</span><a class="self-link" href="#patch-mismatch"></a></h5>
+   <p>TODO(garretrieger): this belongs with info about client handling of the response</p>
+   <p>After a client receives a <a href="#patch-response">§ 2.5 Patch Font Response</a> and computes a new version of the font the client must
+compare the checksum <a href="#computing-checksums">§ 2.8.1 Computing Checksums</a> of the new font to <a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
+client must discard the response and should resend the request as a <a href="#rebase-request">§ 2.2 New Font Request</a>. Upon receiving
+a new copy of the font the client can replace any existing data it has for that font.</p>
    <h5 class="heading settled" data-level="2.3.2.5" id="cmap4-overflow"><span class="secno">2.3.2.5. </span><span class="content">Cmap Format 4 Overflow</span><a class="self-link" href="#cmap4-overflow"></a></h5>
    <h5 class="heading settled" data-level="2.3.2.6" id="offset-overflow"><span class="secno">2.3.2.6. </span><span class="content">Offset Overflow during Subsetting</span><a class="self-link" href="#offset-overflow"></a></h5>
    <h4 class="heading settled" data-level="2.3.3" id="errors"><span class="secno">2.3.3. </span><span class="content">Errors</span><a class="self-link" href="#errors"></a></h4>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="4323928b479dae1c5be34b739a2ccaeca167320f" name="document-revision">
+  <meta content="21286e05b9a955760cc25546fa2b4ffe19c8c29d" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-12">12 May 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-14">14 May 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -447,45 +447,50 @@ dfn > a.self-link::before      { content: "#"; }
      <a href="#patch-incxfer"><span class="secno">2</span> <span class="content">Patch Based Incremental Transfer</span></a>
      <ol class="toc">
       <li>
-       <a href="#data-types"><span class="secno">2.1</span> <span class="content">Data Types</span></a>
+       <a href="#patch-overview"><span class="secno">2.1</span> <span class="content">Overview</span></a>
        <ol class="toc">
-        <li><a href="#encoding"><span class="secno">2.1.1</span> <span class="content">Encoding</span></a>
-        <li><a href="#primitives"><span class="secno">2.1.2</span> <span class="content">Primitives</span></a>
-        <li><a href="#sparsebitset"><span class="secno">2.1.3</span> <span class="content">SparseBitSet</span></a>
-        <li><a href="#objects"><span class="secno">2.1.4</span> <span class="content">Objects</span></a>
+        <li><a href="#font-subset"><span class="secno">2.1.1</span> <span class="content">Font Subset</span></a>
+       </ol>
+      <li>
+       <a href="#data-types"><span class="secno">2.2</span> <span class="content">Data Types</span></a>
+       <ol class="toc">
+        <li><a href="#encoding"><span class="secno">2.2.1</span> <span class="content">Encoding</span></a>
+        <li><a href="#primitives"><span class="secno">2.2.2</span> <span class="content">Primitives</span></a>
+        <li><a href="#sparsebitset"><span class="secno">2.2.3</span> <span class="content">SparseBitSet</span></a>
+        <li><a href="#objects"><span class="secno">2.2.4</span> <span class="content">Objects</span></a>
         <li>
-         <a href="#schemas"><span class="secno">2.1.5</span> <span class="content">Object Schemas</span></a>
+         <a href="#schemas"><span class="secno">2.2.5</span> <span class="content">Object Schemas</span></a>
          <ol class="toc">
-          <li><a href="#CompressedList"><span class="secno">2.1.5.1</span> <span class="content">CompressedList</span></a>
-          <li><a href="#CompressedSet"><span class="secno">2.1.5.2</span> <span class="content">CompressedSet</span></a>
-          <li><a href="#PatchRequest"><span class="secno">2.1.5.3</span> <span class="content">PatchRequest</span></a>
-          <li><a href="#PatchResponse"><span class="secno">2.1.5.4</span> <span class="content">PatchResponse</span></a>
+          <li><a href="#CompressedList"><span class="secno">2.2.5.1</span> <span class="content">CompressedList</span></a>
+          <li><a href="#CompressedSet"><span class="secno">2.2.5.2</span> <span class="content">CompressedSet</span></a>
+          <li><a href="#PatchRequest"><span class="secno">2.2.5.3</span> <span class="content">PatchRequest</span></a>
+          <li><a href="#PatchResponse"><span class="secno">2.2.5.4</span> <span class="content">PatchResponse</span></a>
          </ol>
        </ol>
       <li>
-       <a href="#client"><span class="secno">2.2</span> <span class="content">Client</span></a>
+       <a href="#client"><span class="secno">2.3</span> <span class="content">Client</span></a>
        <ol class="toc">
-        <li><a href="#client-state"><span class="secno">2.2.1</span> <span class="content">Client State</span></a>
-        <li><a href="#extend-subset"><span class="secno">2.2.2</span> <span class="content">Extending the Font Subset</span></a>
-        <li><a href="#handling-patch-response"><span class="secno">2.2.3</span> <span class="content">Handling PatchResponse</span></a>
-        <li><a href="#client-side-checksum-mismatch"><span class="secno">2.2.4</span> <span class="content">Client Side Checksum Mismatch</span></a>
+        <li><a href="#client-state"><span class="secno">2.3.1</span> <span class="content">Client State</span></a>
+        <li><a href="#extend-subset"><span class="secno">2.3.2</span> <span class="content">Extending the Font Subset</span></a>
+        <li><a href="#handling-patch-response"><span class="secno">2.3.3</span> <span class="content">Handling PatchResponse</span></a>
+        <li><a href="#client-side-checksum-mismatch"><span class="secno">2.3.4</span> <span class="content">Client Side Checksum Mismatch</span></a>
        </ol>
       <li>
-       <a href="#server"><span class="secno">2.3</span> <span class="content">Server</span></a>
+       <a href="#server"><span class="secno">2.4</span> <span class="content">Server</span></a>
        <ol class="toc">
-        <li><a href="#handling-patch-request"><span class="secno">2.3.1</span> <span class="content">Responding to a PatchRequest</span></a>
+        <li><a href="#handling-patch-request"><span class="secno">2.4.1</span> <span class="content">Responding to a PatchRequest</span></a>
        </ol>
       <li>
-       <a href="#procedures"><span class="secno">2.4</span> <span class="content">Procedures</span></a>
+       <a href="#procedures"><span class="secno">2.5</span> <span class="content">Procedures</span></a>
        <ol class="toc">
-        <li><a href="#computing-checksums"><span class="secno">2.4.1</span> <span class="content">Computing Checksums</span></a>
+        <li><a href="#computing-checksums"><span class="secno">2.5.1</span> <span class="content">Computing Checksums</span></a>
         <li>
-         <a href="#codepoint-reordering"><span class="secno">2.4.2</span> <span class="content">Codepoint Reordering</span></a>
+         <a href="#codepoint-reordering"><span class="secno">2.5.2</span> <span class="content">Codepoint Reordering</span></a>
          <ol class="toc">
-          <li><a href="#reordering-checksum"><span class="secno">2.4.2.1</span> <span class="content">Computing Checksum</span></a>
-          <li><a href="#reordering-algorithm"><span class="secno">2.4.2.2</span> <span class="content">Recommended algorithm</span></a>
+          <li><a href="#reordering-checksum"><span class="secno">2.5.2.1</span> <span class="content">Computing Checksum</span></a>
+          <li><a href="#reordering-algorithm"><span class="secno">2.5.2.2</span> <span class="content">Recommended algorithm</span></a>
          </ol>
-        <li><a href="#patch-formats"><span class="secno">2.4.3</span> <span class="content">Patch and Compression Formats</span></a>
+        <li><a href="#patch-formats"><span class="secno">2.5.3</span> <span class="content">Patch and Compression Formats</span></a>
        </ol>
      </ol>
     <li><a href="#range-request-incxfer"><span class="secno">3</span> <span class="content">Range Request Incremental Transfer</span></a>
@@ -518,16 +523,28 @@ dfn > a.self-link::before      { content: "#"; }
    <p>The success of WebFonts is unevenly distributed. This specification allows WebFonts to be used where slow networks, very large fonts, or complex subsetting requirements currently preclude their use. For example, even using WOFF 2 <a data-link-type="biblio" href="#biblio-woff2">[WOFF2]</a>, fonts for CJK languages are too large to be practical.</p>
    <p>See the Progressive Font Enrichment: Evaluation Report <a data-link-type="biblio" href="#biblio-pfe-report">[PFE-report]</a> for the investigation which led to this specification.</p>
    <h2 class="heading settled" data-level="2" id="patch-incxfer"><span class="secno">2. </span><span class="content">Patch Based Incremental Transfer</span><a class="self-link" href="#patch-incxfer"></a></h2>
-   <p>TODO(garretrieger): Describe the high level version of how this version operates.</p>
-   <p>TODO(garretrieger): Describe font subsetting.</p>
-   <h3 class="heading settled" data-level="2.1" id="data-types"><span class="secno">2.1. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
+   <h3 class="heading settled" data-level="2.1" id="patch-overview"><span class="secno">2.1. </span><span class="content">Overview</span><a class="self-link" href="#patch-overview"></a></h3>
+   <p>In the patch subset approach to incremental font transfer a server generates binary patches which a
+client applies to a subset of the font in order to extend the coverage of that font subset. The server
+is stateless, it does not maintain any session data for clients between requests. Thus when a client
+requests the generation of a patch from the server it must fully describe the current subset of the
+font that it has in a way which allows the server to recreate it.</p>
+   <p>Generic binary patch algorithms are used which do not need to be aware of the specifics of the font
+format. Typically a server will produce a patch by generating two font subsets: one which matches what
+the client currently has and one which matches the extended subset the client desires. A binary patch
+is then produced between the two subsets.</p>
+   <h4 class="heading settled" data-level="2.1.1" id="font-subset"><span class="secno">2.1.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset"></a></h4>
+   <p>A subset of a font file is a modified version of the font that contains only the data needed to
+render a subset of the codepoints in the original font. A subsetted font should be able to render
+any permutation of the codepoints in the subset identically to the original font.</p>
+   <h3 class="heading settled" data-level="2.2" id="data-types"><span class="secno">2.2. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
    <p>This section lists all of the data types that are used to form the request and response messages
 sent between the client and server.</p>
-   <h4 class="heading settled" data-level="2.1.1" id="encoding"><span class="secno">2.1.1. </span><span class="content">Encoding</span><a class="self-link" href="#encoding"></a></h4>
+   <h4 class="heading settled" data-level="2.2.1" id="encoding"><span class="secno">2.2.1. </span><span class="content">Encoding</span><a class="self-link" href="#encoding"></a></h4>
    <p>All data types defined here are encoded into a byte representation for transport using CBOR
 (Concise Binary Object Representation) <a data-link-type="biblio" href="#biblio-rfc8949">[rfc8949]</a>. More information on how each data types
 should be encoded by CBOR are given in the definition of those data types.</p>
-   <h4 class="heading settled" data-level="2.1.2" id="primitives"><span class="secno">2.1.2. </span><span class="content">Primitives</span><a class="self-link" href="#primitives"></a></h4>
+   <h4 class="heading settled" data-level="2.2.2" id="primitives"><span class="secno">2.2.2. </span><span class="content">Primitives</span><a class="self-link" href="#primitives"></a></h4>
    <table>
     <tbody>
      <tr>
@@ -547,7 +564,7 @@ should be encoded by CBOR are given in the definition of those data types.</p>
       <td>Array of a variable number of items of Type
       <td>4
    </table>
-   <h4 class="heading settled" data-level="2.1.3" id="sparsebitset"><span class="secno">2.1.3. </span><span class="content">SparseBitSet</span><a class="self-link" href="#sparsebitset"></a></h4>
+   <h4 class="heading settled" data-level="2.2.3" id="sparsebitset"><span class="secno">2.2.3. </span><span class="content">SparseBitSet</span><a class="self-link" href="#sparsebitset"></a></h4>
    <p>A data structure which compactly stores a set of distinct unsigned integers. The set is represented as
 a tree where each node has a fixed number of children that recursively sub-divides an interval into
 equal partitions. A tree of height <i>H</i> with branching factor <i>B</i> can store set membership
@@ -706,7 +723,7 @@ significant bit in the byte and the bit with the largest index is the most signi
       <p>n<sub>3</sub> append 0011. Bit 0 set for value 16, bit 1 set for value 17.</p>
     </ul>
    </div>
-   <h4 class="heading settled" data-level="2.1.4" id="objects"><span class="secno">2.1.4. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
+   <h4 class="heading settled" data-level="2.2.4" id="objects"><span class="secno">2.2.4. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
    <p>Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps
 (major type 5). Each key and value pair is encoded as a single map entry. Keys are always unsigned
 integers and are encoded using major type 0. Values are encoded using the encoding specified by the
@@ -714,7 +731,7 @@ type of the value.</p>
    <p>All fields in an object are optional and do not need to have an associated value. Conversely when
 decoding and object fields may be present which are not specified in the schema. The decoder must
 ignore without error any key and value pairs where the key is not recognized.</p>
-   <p>There are several types of object used, each type is defined by a schema in <a href="#schemas">§ 2.1.5 Object Schemas</a>. The schema
+   <p>There are several types of object used, each type is defined by a schema in <a href="#schemas">§ 2.2.5 Object Schemas</a>. The schema
 for a type specifies for each field:</p>
    <ul>
     <li data-md>
@@ -722,10 +739,10 @@ for a type specifies for each field:</p>
     <li data-md>
      <p>A unsigned integer id for the field. This is used as the key in the encoding.</p>
     <li data-md>
-     <p>The type of the value stored in this field. Can be any of the types defined in <a href="#data-types">§ 2.1 Data Types</a> including object types.</p>
+     <p>The type of the value stored in this field. Can be any of the types defined in <a href="#data-types">§ 2.2 Data Types</a> including object types.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.1.5" id="schemas"><span class="secno">2.1.5. </span><span class="content">Object Schemas</span><a class="self-link" href="#schemas"></a></h4>
-   <h5 class="heading settled" data-level="2.1.5.1" id="CompressedList"><span class="secno">2.1.5.1. </span><span class="content">CompressedList</span><a class="self-link" href="#CompressedList"></a></h5>
+   <h4 class="heading settled" data-level="2.2.5" id="schemas"><span class="secno">2.2.5. </span><span class="content">Object Schemas</span><a class="self-link" href="#schemas"></a></h4>
+   <h5 class="heading settled" data-level="2.2.5.1" id="CompressedList"><span class="secno">2.2.5.1. </span><span class="content">CompressedList</span><a class="self-link" href="#CompressedList"></a></h5>
    <table>
     <tbody>
      <tr>
@@ -746,7 +763,7 @@ if len(value_deltas) > 0:
     value_deltas[i] = L[i] - L[i-1]
 </pre>
    <div class="example" id="example-6e146a01"><a class="self-link" href="#example-6e146a01"></a> The list [2, 2, 5, 1, 3, 7] would be encoded as [2, 0, 3, -4, 2, 4]. </div>
-   <h5 class="heading settled" data-level="2.1.5.2" id="CompressedSet"><span class="secno">2.1.5.2. </span><span class="content">CompressedSet</span><a class="self-link" href="#CompressedSet"></a></h5>
+   <h5 class="heading settled" data-level="2.2.5.2" id="CompressedSet"><span class="secno">2.2.5.2. </span><span class="content">CompressedSet</span><a class="self-link" href="#CompressedSet"></a></h5>
    <p>Encodes a set of unsigned integers. The set is not ordered and does not
 allow duplicates. Members of the set are encoded into either a sparse bit
 set or a list of ranges. To obtain the final set the members of the sparse
@@ -768,7 +785,7 @@ bit set and the list of ranges are unioned together.</p>
       <td>range_deltas
       <td>ArrayOf&lt;Integer>
    </table>
-   <h5 class="heading settled" data-level="2.1.5.3" id="PatchRequest"><span class="secno">2.1.5.3. </span><span class="content">PatchRequest</span><a class="self-link" href="#PatchRequest"></a></h5>
+   <h5 class="heading settled" data-level="2.2.5.3" id="PatchRequest"><span class="secno">2.2.5.3. </span><span class="content">PatchRequest</span><a class="self-link" href="#PatchRequest"></a></h5>
    <table>
     <tbody>
      <tr>
@@ -817,14 +834,14 @@ bit set and the list of ranges are unioned together.</p>
     <li data-md>
      <p><code>protocol_version</code> must be set to 0.</p>
     <li data-md>
-     <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a>.</p>
+     <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 2.5.3 Patch and Compression Formats</a>.</p>
     <li data-md>
      <p>If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
 then <code>ordering_checksum</code> must be set.</p>
     <li data-md>
      <p>If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then <code>original_font_checksum</code> and <code>base_checksum</code> must be set.</p>
    </ul>
-   <h5 class="heading settled" data-level="2.1.5.4" id="PatchResponse"><span class="secno">2.1.5.4. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h5>
+   <h5 class="heading settled" data-level="2.2.5.4" id="PatchResponse"><span class="secno">2.2.5.4. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h5>
    <table>
     <tbody>
      <tr>
@@ -863,7 +880,7 @@ then <code>ordering_checksum</code> must be set.</p>
    <p>For a PatchRequest object to be well formed:</p>
    <ul>
     <li data-md>
-     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a></p>
+     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.5.3 Patch and Compression Formats</a></p>
     <li data-md>
      <p>Only one of <code>patch</code> and <code>replacement</code> may be set.</p>
     <li data-md>
@@ -871,8 +888,8 @@ then <code>ordering_checksum</code> must be set.</p>
     <li data-md>
      <p>If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.</p>
    </ul>
-   <h3 class="heading settled" data-level="2.2" id="client"><span class="secno">2.2. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
-   <h4 class="heading settled" data-level="2.2.1" id="client-state"><span class="secno">2.2.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
+   <h3 class="heading settled" data-level="2.3" id="client"><span class="secno">2.3. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
+   <h4 class="heading settled" data-level="2.3.1" id="client-state"><span class="secno">2.3.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
    <p>The client will need to maintain at minimum the following state for each font file being incrementally
 transferred:</p>
    <ul>
@@ -883,13 +900,12 @@ the font being incrementally transferred. For a new font this is initialized to 
      <p>Original font checksum: the most recent value of <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
 from the server for this font.</p>
     <li data-md>
-     <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> received from the server
+     <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.5.2 Codepoint Reordering</a> received from the server
 for this font.</p>
     <li data-md>
      <p>Codepoint Reordering Checksum: The most recent <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> for this font.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.2.2" id="extend-subset"><span class="secno">2.2.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
-   <p>TODO(garretrieger): mention how the url identifies the specific font being requested.</p>
+   <h4 class="heading settled" data-level="2.3.2" id="extend-subset"><span class="secno">2.3.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
    <p>A client extends its font subset to cover additional codepoints by making HTTP requests to
 a Patch Subset server. The HTTP request must use either the GET or POST method:</p>
    <ul>
@@ -899,13 +915,15 @@ a Patch Subset server. The HTTP request must use either the GET or POST method:<
      <p>If sent as a GET request the client will include a single query parameter, <code>request</code>:<br> the value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then base64url
 encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>.</p>
    </ul>
+   <p>For both POST and GET requests the path of the request identifies the specific font. All requests
+must be made over HTTPS.</p>
    <p>The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
 as follows:</p>
    <ul>
     <li data-md>
      <p><code>protocol_version</code>: set to 0.</p>
     <li data-md>
-     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 2.4.3 Patch and Compression Formats</a> that this client is
+     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 2.5.3 Patch and Compression Formats</a> that this client is
 capable of decoding. Must contain at least one format.</p>
     <li data-md>
      <p><code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
@@ -917,11 +935,11 @@ add to its font subset. If the client has a codepoint ordering for this font the
 field should not be set.</p>
     <li data-md>
      <p><code>indices_have</code>: encodes the set of codepoints that the current
-font subset contains data for. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+font subset contains data for. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.5.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
 ordering for this font then this field should not be set.</p>
     <li data-md>
      <p><code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
-font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.4.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.5.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
 ordering for this font then this field should not be set.</p>
     <li data-md>
      <p><code>ordering_checksum</code>: If either of <code>indices_have</code> or <code>indices_needed</code> is set then this must be set to the current value of <code>ordering_checksum</code> saved in the state for this font.</p>
@@ -931,9 +949,9 @@ Set to saved value for <code>original_font_checksum</code> in the state for this
 there is no saved value leave this field unset.</p>
     <li data-md>
      <p><code>base_checksum</code>:
-Set to the checksum of the font subset byte array saved in the state for this font. See: <a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>.</p>
+Set to the checksum of the font subset byte array saved in the state for this font. See: <a href="#computing-checksums">§ 2.5.1 Computing Checksums</a>.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.2.3" id="handling-patch-response"><span class="secno">2.2.3. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h4>
+   <h4 class="heading settled" data-level="2.3.3" id="handling-patch-response"><span class="secno">2.3.3. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h4>
    <p>If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a> if will respond with HTTP status code 200 and the body of the response will be a <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
 should interpret and process the fields of the object as follows:</p>
    <ol>
@@ -947,7 +965,7 @@ in the format specified by <code>patch_format</code>. Apply the binary patch to 
 subset. Replace the saved font subset with the result of the patch application.</p>
     <li data-md>
      <p>If either <code>replacement</code> or <code>patch</code> is set then: <a href="#computing-checksums">compute the checksum</a> of the font subset produced by the patch
-application in steps 1 or 2. If the computed checksum is not equal to <code>patched_checksum</code> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.4 Client Side Checksum Mismatch</a>. Otherwise
+application in steps 1 or 2. If the computed checksum is not equal to <code>patched_checksum</code> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 2.3.4 Client Side Checksum Mismatch</a>. Otherwise
 update the saved original font checksum with the value in <code>original_font_checksum</code>.</p>
     <li data-md>
      <p>If fields <code>codepoint_ordering</code> and <code>ordering_checksum</code> are set then update
@@ -956,8 +974,7 @@ If neither <code>replacement</code> or <code>patch</code> are set, then the clie
 resend the request that triggered this response but use the new codepoint ordering provided in
 this response.</p>
    </ol>
-   <p>TODO(garretrieger): how to handle error status codes (ie. 4xx, 5xx).</p>
-   <h4 class="heading settled" data-level="2.2.4" id="client-side-checksum-mismatch"><span class="secno">2.2.4. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
+   <h4 class="heading settled" data-level="2.3.4" id="client-side-checksum-mismatch"><span class="secno">2.3.4. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
    <p>If the the checksum of the font subset computed by the client does not match the <code>patched_checksum</code> in the server’s response then the client should:</p>
    <ol>
     <li data-md>
@@ -967,15 +984,13 @@ this response.</p>
 to the union of the codepoints in the discarded font subset and the set of code points
 the the previous request was trying to add.</p>
    </ol>
-   <h3 class="heading settled" data-level="2.3" id="server"><span class="secno">2.3. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
-   <h4 class="heading settled" data-level="2.3.1" id="handling-patch-request"><span class="secno">2.3.1. </span><span class="content">Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h4>
-   <p>TODO(garretrieger): url identifies the font being operated on ('the requested font')
-TODO(garretrieger): https only.
-TODO(garretrieger): Identify at least one patch format which all client/servers must support.</p>
-   <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> that
-was populated according to the requirements in <a href="#extend-subset">§ 2.2.2 Extending the Font Subset</a> then it should respond with HTTP
-status code 200. The body of the response should be a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>
-   <p>From the request object the server can produce two codepoint sets:</p>
+   <h3 class="heading settled" data-level="2.4" id="server"><span class="secno">2.4. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
+   <h4 class="heading settled" data-level="2.4.1" id="handling-patch-request"><span class="secno">2.4.1. </span><span class="content">Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
+HTTPS that was populated according to the requirements in <a href="#extend-subset">§ 2.3.2 Extending the Font Subset</a> then it should
+respond with HTTP status code 200. The body of the response should be a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>
+   <p>The path in the request identifies the specific font that a patch is desired for. From the request
+object the server can produce two codepoint sets:</p>
    <ol>
     <li data-md>
      <p>Codepoints the client has: formed by the union of the codepoint sets specified by <code>codepoints_have</code> and <code>indices_have</code>. The indices in <code>indices_have</code> must be mapped to codepoints by the application of the
@@ -986,34 +1001,35 @@ status code 200. The body of the response should be a single <a href="#PatchRequ
    </ol>
    <p>If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
-will recognize via the process described in <a href="#handling-patch-response">§ 2.2.3 Handling PatchResponse</a> and not include any patch.
+will recognize via the process described in <a href="#handling-patch-response">§ 2.3.3 Handling PatchResponse</a> and not include any patch.
 That is the <code>patch</code> and <code>replacement</code> fields must not be set.</p>
-   <p>Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 2.2.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result in an extended font subset that contains
-data for at least the union of the set of codepoints needed and the sets of codepoints the client already
-has. The format of patch in the either the <code>patch</code> or <code>replace</code> field must be one of
-those listed in <code>accept_patch_format</code>.</p>
-   <p class="note" role="note"><span>Note:</span> the server can respond with either a patch or a replacement but should try to produce a patch where possible.
-      replacement’s should only be used in situations where the server is unable to recreate the clients state
-      in order to generate a patch against it.</p>
+   <p>Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 2.3.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result
+in an extended font subset that contains data for at least the union of the set of codepoints needed
+and the sets of codepoints the client already has. The format of patch in the either the <code>patch</code> or <code>replace</code> field must be one of those listed in <code>accept_patch_format</code>.</p>
+   <p class="note" role="note"><span>Note:</span> the server can respond with either a patch or a replacement but should try to produce a patch
+where possible. Replacement’s should only be used in situations where the server is unable to recreate
+the clients state in order to generate a patch against it.</p>
    <p>Possible error responses:</p>
    <ul>
     <li data-md>
-     <p>If the request is malformed the server may instead respond with http status code 400 to indicate an error.</p>
+     <p>If the request is malformed the server may instead respond with http status code 400 to indicate an
+error.</p>
     <li data-md>
-     <p>If the requested font is not recognized by the server it may respond with http status code 404 to indicate
-a not found error.</p>
+     <p>If the requested font is not recognized by the server it may respond with http status code 404 to
+indicate a not found error.</p>
    </ul>
-   <h3 class="heading settled" data-level="2.4" id="procedures"><span class="secno">2.4. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
-   <h4 class="heading settled" data-level="2.4.1" id="computing-checksums"><span class="secno">2.4.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
+   <h3 class="heading settled" data-level="2.5" id="procedures"><span class="secno">2.5. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
+   <h4 class="heading settled" data-level="2.5.1" id="computing-checksums"><span class="secno">2.5.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.4.2" id="codepoint-reordering"><span class="secno">2.4.2. </span><span class="content">Codepoint Reordering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
+   <h4 class="heading settled" data-level="2.5.2" id="codepoint-reordering"><span class="secno">2.5.2. </span><span class="content">Codepoint Reordering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.4.2.1" id="reordering-checksum"><span class="secno">2.4.2.1. </span><span class="content">Computing Checksum</span><a class="self-link" href="#reordering-checksum"></a></h5>
+   <h5 class="heading settled" data-level="2.5.2.1" id="reordering-checksum"><span class="secno">2.5.2.1. </span><span class="content">Computing Checksum</span><a class="self-link" href="#reordering-checksum"></a></h5>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.4.2.2" id="reordering-algorithm"><span class="secno">2.4.2.2. </span><span class="content">Recommended algorithm</span><a class="self-link" href="#reordering-algorithm"></a></h5>
+   <h5 class="heading settled" data-level="2.5.2.2" id="reordering-algorithm"><span class="secno">2.5.2.2. </span><span class="content">Recommended algorithm</span><a class="self-link" href="#reordering-algorithm"></a></h5>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.4.3" id="patch-formats"><span class="secno">2.4.3. </span><span class="content">Patch and Compression Formats</span><a class="self-link" href="#patch-formats"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
+   <h4 class="heading settled" data-level="2.5.3" id="patch-formats"><span class="secno">2.5.3. </span><span class="content">Patch and Compression Formats</span><a class="self-link" href="#patch-formats"></a></h4>
+   <p>TODO(garretrieger): write this.
+TODO(garretrieger): Identify at least one patch format which all client/servers must support.</p>
    <h2 class="heading settled" data-level="3" id="range-request-incxfer"><span class="secno">3. </span><span class="content">Range Request Incremental Transfer</span><a class="self-link" href="#range-request-incxfer"></a></h2>
    <h2 class="heading settled" data-level="4" id="negotiating-transfer-type"><span class="secno">4. </span><span class="content">Negotiating Incremental Transfer Type</span><a class="self-link" href="#negotiating-transfer-type"></a></h2>
    <h2 class="no-num heading settled" id="priv-sec"><span class="content">Privacy and Security Considerations</span><a class="self-link" href="#priv-sec"></a></h2>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="21286e05b9a955760cc25546fa2b4ffe19c8c29d" name="document-revision">
+  <meta content="a99db07bb595ee401026f40fe592193e25f676d1" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -490,7 +490,7 @@ dfn > a.self-link::before      { content: "#"; }
           <li><a href="#reordering-checksum"><span class="secno">2.5.2.1</span> <span class="content">Computing Checksum</span></a>
           <li><a href="#reordering-algorithm"><span class="secno">2.5.2.2</span> <span class="content">Recommended algorithm</span></a>
          </ol>
-        <li><a href="#patch-formats"><span class="secno">2.5.3</span> <span class="content">Patch and Compression Formats</span></a>
+        <li><a href="#patch-formats"><span class="secno">2.5.3</span> <span class="content">Patch Formats</span></a>
        </ol>
      </ol>
     <li><a href="#range-request-incxfer"><span class="secno">3</span> <span class="content">Range Request Incremental Transfer</span></a>
@@ -834,7 +834,7 @@ bit set and the list of ranges are unioned together.</p>
     <li data-md>
      <p><code>protocol_version</code> must be set to 0.</p>
     <li data-md>
-     <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 2.5.3 Patch and Compression Formats</a>.</p>
+     <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 2.5.3 Patch Formats</a>.</p>
     <li data-md>
      <p>If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
 then <code>ordering_checksum</code> must be set.</p>
@@ -880,7 +880,7 @@ then <code>ordering_checksum</code> must be set.</p>
    <p>For a PatchRequest object to be well formed:</p>
    <ul>
     <li data-md>
-     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.5.3 Patch and Compression Formats</a></p>
+     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.5.3 Patch Formats</a></p>
     <li data-md>
      <p>Only one of <code>patch</code> and <code>replacement</code> may be set.</p>
     <li data-md>
@@ -923,7 +923,7 @@ as follows:</p>
     <li data-md>
      <p><code>protocol_version</code>: set to 0.</p>
     <li data-md>
-     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 2.5.3 Patch and Compression Formats</a> that this client is
+     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 2.5.3 Patch Formats</a> that this client is
 capable of decoding. Must contain at least one format.</p>
     <li data-md>
      <p><code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
@@ -1027,9 +1027,27 @@ indicate a not found error.</p>
    <p>TODO(garretrieger): write this.</p>
    <h5 class="heading settled" data-level="2.5.2.2" id="reordering-algorithm"><span class="secno">2.5.2.2. </span><span class="content">Recommended algorithm</span><a class="self-link" href="#reordering-algorithm"></a></h5>
    <p>TODO(garretrieger): write this.</p>
-   <h4 class="heading settled" data-level="2.5.3" id="patch-formats"><span class="secno">2.5.3. </span><span class="content">Patch and Compression Formats</span><a class="self-link" href="#patch-formats"></a></h4>
-   <p>TODO(garretrieger): write this.
-TODO(garretrieger): Identify at least one patch format which all client/servers must support.</p>
+   <h4 class="heading settled" data-level="2.5.3" id="patch-formats"><span class="secno">2.5.3. </span><span class="content">Patch Formats</span><a class="self-link" href="#patch-formats"></a></h4>
+   <p>The following patch formats may be used by the server to create binary diffs between a source file
+and a target file:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Format
+      <th>Value
+      <th>Notes
+     <tr>
+      <td>VCDIFF
+      <td>0
+      <td>Uses VCDIFF format <a data-link-type="biblio" href="#biblio-rfc3284">[rfc3284]</a> to produce the patch. All client and server implementations
+    must support this format.
+     <tr>
+      <td>Brotli Shared Dictionary
+      <td>1
+      <td>Uses brotli compression <a data-link-type="biblio" href="#biblio-rfc7932">[rfc7932]</a> to produce the patch. The source file is used as a shared
+    dictionary given to the brotli compressor and decompressor.
+   </table>
+   <p>TODO(garretrieger): reference updated brotli spec which includes shared dictionary.</p>
    <h2 class="heading settled" data-level="3" id="range-request-incxfer"><span class="secno">3. </span><span class="content">Range Request Incremental Transfer</span><a class="self-link" href="#range-request-incxfer"></a></h2>
    <h2 class="heading settled" data-level="4" id="negotiating-transfer-type"><span class="secno">4. </span><span class="content">Negotiating Incremental Transfer Type</span><a class="self-link" href="#negotiating-transfer-type"></a></h2>
    <h2 class="no-num heading settled" id="priv-sec"><span class="content">Privacy and Security Considerations</span><a class="self-link" href="#priv-sec"></a></h2>
@@ -1085,6 +1103,10 @@ TODO(garretrieger): Identify at least one patch format which all client/servers 
   <dl>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc3284">[RFC3284]
+   <dd>D. Korn; et al. <a href="https://datatracker.ietf.org/doc/html/rfc3284">The VCDIFF Generic Differencing and Compression Data Format</a>. June 2002. Proposed Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc3284">https://datatracker.ietf.org/doc/html/rfc3284</a>
+   <dt id="biblio-rfc7932">[RFC7932]
+   <dd>J. Alakuijala; Z. Szabadka. <a href="https://datatracker.ietf.org/doc/html/rfc7932">Brotli Compressed Data Format</a>. July 2016. Informational. URL: <a href="https://datatracker.ietf.org/doc/html/rfc7932">https://datatracker.ietf.org/doc/html/rfc7932</a>
    <dt id="biblio-rfc8949">[RFC8949]
    <dd>C. Bormann; P. Hoffman. <a href="https://datatracker.ietf.org/doc/html/rfc8949">Concise Binary Object Representation (CBOR)</a>. December 2020. Internet Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8949">https://datatracker.ietf.org/doc/html/rfc8949</a>
   </dl>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="181d77a1915f5f9c92401b69acccec9801ebbe76" name="document-revision">
+  <meta content="552c983b5cc8933a9a72ac1f79a5966314eea1db" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-06">6 May 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-05-07">7 May 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -474,12 +474,9 @@ dfn > a.self-link::before      { content: "#"; }
          </ol>
         <li><a href="#patch-request"><span class="secno">2.2.3</span> <span class="content">Patch Font Request</span></a>
         <li><a href="#handling-rebase-response"><span class="secno">2.2.4</span> <span class="content">Handling New Font Response</span></a>
-        <li>
-         <a href="#handling-patch-response"><span class="secno">2.2.5</span> <span class="content">Handling Patch Font Response</span></a>
-         <ol class="toc">
-          <li><a href="#patch-mismatch"><span class="secno">2.2.5.1</span> <span class="content">Client Side Patched Base Checksum Mismatch</span></a>
-         </ol>
+        <li><a href="#handling-patch-response"><span class="secno">2.2.5</span> <span class="content">Handling Patch Font Response</span></a>
         <li><a href="#handling-reindex-response"><span class="secno">2.2.6</span> <span class="content">Handling Update Codepoint Ordering Response</span></a>
+        <li><a href="#client-side-checksum-mismatch"><span class="secno">2.2.7</span> <span class="content">Client Side Checksum Mismatch</span></a>
        </ol>
       <li>
        <a href="#server"><span class="secno">2.3</span> <span class="content">Server</span></a>
@@ -488,8 +485,8 @@ dfn > a.self-link::before      { content: "#"; }
         <li>
          <a href="#handling-patch-request"><span class="secno">2.3.2</span> <span class="content">Handling Patch Font Request</span></a>
          <ol class="toc">
-          <li><a href="#client-font-mismatch"><span class="secno">2.3.2.1</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
-          <li><a href="#client-base-mismatch"><span class="secno">2.3.2.2</span> <span class="content">Client’s Base does not Match Server’s</span></a>
+          <li><a href="#client-base-mismatch"><span class="secno">2.3.2.1</span> <span class="content">Client’s Base does not Match Server’s</span></a>
+          <li><a href="#client-font-mismatch"><span class="secno">2.3.2.2</span> <span class="content">Client’s Original Font does not Match Server’s</span></a>
           <li><a href="#codepoint-reordering-mismatch"><span class="secno">2.3.2.3</span> <span class="content">Client Codepoint Reordering does not Match Servers</span></a>
           <li><a href="#subsetting-failures"><span class="secno">2.3.2.4</span> <span class="content">Subsetting Failures</span></a>
          </ol>
@@ -968,7 +965,7 @@ The codepoint values are transformed to indices by applying <code>codepoint orde
 the font.</p>
    </ul>
    <h4 class="heading settled" data-level="2.2.4" id="handling-rebase-response"><span class="secno">2.2.4. </span><span class="content">Handling New Font Response</span><a class="self-link" href="#handling-rebase-response"></a></h4>
-   <p>If in response to a request made for a font a client receives a <a href="#rebase-response">§ 2.3.3 New Font Response</a> it must:</p>
+   <p>If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a> is equal to REBASE, then the client must:</p>
    <ol>
     <li data-md>
      <p>Decode the contents of <a href="#PatchResponse"><code>PatchResponse.patch</code></a> using
@@ -987,21 +984,51 @@ original font checksum, and <a href="#PatchResponse"><code>PatchResponse.origina
 codepoint reordering map.</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.5" id="handling-patch-response"><span class="secno">2.2.5. </span><span class="content">Handling Patch Font Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
-   <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.2.5.1" id="patch-mismatch"><span class="secno">2.2.5.1. </span><span class="content">Client Side Patched Base Checksum Mismatch</span><a class="self-link" href="#patch-mismatch"></a></h5>
-   <p>After a client receives a <a href="#patch-response">§ 2.3.4 Patch Font Response</a> and computes a new version of the font the client must
-compare the checksum <a href="#computing-checksums">§ 2.4.1 Computing Checksums</a> of the new font to <a href="#PatchResponse"><code>PatchResponse.patch.patched_checksum</code></a>. If they differ, the
-client must discard the response and should resend the request as a <a href="#rebase-request">§ 2.2.2 New Font Request</a>. Upon receiving
-a new copy of the font the client can replace any existing data it has for that font.</p>
+   <p>If a response is received where <a href="#PatchResponse"><code>PatchResponse.response_type</code></a> is equal to PATCH, then the client must:</p>
+   <ol>
+    <li data-md>
+     <p>Check that <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> matches the original font checksum stored in the clients state. If they do not match
+ this is a recoverable error, follow the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.7 Client Side Checksum Mismatch</a>.</p>
+    <li data-md>
+     <p>Apply the decoded patch to the client’s font subset. The format of the patch is specified
+ by the <a href="#PatchResponse"><code>PatchResponse.patch_format</code></a> field. This
+ produces a extended font subset. Replace the previous font subset stored in the client’s
+ state with this the new one.</p>
+    <li data-md>
+     <p>Compute the checksum (<a href="#computing-checksums">§ 2.4.1 Computing Checksums</a>) of the extended font subset.</p>
+    <li data-md>
+     <p>Check that <a href="#PatchResponse"><code>PatchResponse.patched_checksum</code></a> matches
+ the computed checksum in step 3. If they do not match this is a recoverable error, follow
+ the procedure in <a href="#client-side-checksum-mismatch">§ 2.2.7 Client Side Checksum Mismatch</a>.</p>
+    <li data-md>
+     <p>If <a href="#PatchResponse"><code>PatchResponse.codepoint_ordering</code></a> and <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> have been set
+ then replace the codepoint ordering and checksum saved in the clients state with the new one
+ specified in the response.</p>
+   </ol>
    <h4 class="heading settled" data-level="2.2.6" id="handling-reindex-response"><span class="secno">2.2.6. </span><span class="content">Handling Update Codepoint Ordering Response</span><a class="self-link" href="#handling-reindex-response"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <p>TODO reorganize sections below here</p>
+   <h4 class="heading settled" data-level="2.2.7" id="client-side-checksum-mismatch"><span class="secno">2.2.7. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
+   <p>If either the clients saved original font checksum or the checksum of the patched font subset
+do not match the checksums provided in a response from the server then the client should:</p>
+   <ol>
+    <li data-md>
+     <p>Discard all currently saved state for this font.</p>
+    <li data-md>
+     <p>Resend the request as a <a href="#rebase-request">§ 2.2.2 New Font Request</a> with the codepoints that are currently needed.</p>
+   </ol>
    <h3 class="heading settled" data-level="2.3" id="server"><span class="secno">2.3. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
+   <p>TODO reorganize sections below here</p>
    <h4 class="heading settled" data-level="2.3.1" id="handling-rebase-request"><span class="secno">2.3.1. </span><span class="content">Handling New Font Request</span><a class="self-link" href="#handling-rebase-request"></a></h4>
    <p>TODO(garretrieger): write this.</p>
    <h4 class="heading settled" data-level="2.3.2" id="handling-patch-request"><span class="secno">2.3.2. </span><span class="content">Handling Patch Font Request</span><a class="self-link" href="#handling-patch-request"></a></h4>
    <p>TODO(garretrieger): write this.</p>
-   <h5 class="heading settled" data-level="2.3.2.1" id="client-font-mismatch"><span class="secno">2.3.2.1. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h5>
+   <h5 class="heading settled" data-level="2.3.2.1" id="client-base-mismatch"><span class="secno">2.3.2.1. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h5>
+   <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
+the base font that a server computes not matching the base font that a client has. This case can be
+detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
+with a <a href="#rebase-response">§ 2.3.3 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The replacement font must cover
+at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
+   <h5 class="heading settled" data-level="2.3.2.2" id="client-font-mismatch"><span class="secno">2.3.2.2. </span><span class="content">Client’s Original Font does not Match Server’s</span><a class="self-link" href="#client-font-mismatch"></a></h5>
    <p>Over time servers may upgrade the original copies of a font with newer
 versions. After such an upgrade, clients who have subsets built from the
 previous versions may contact the server and request a patch against the
@@ -1022,12 +1049,6 @@ version of the font it has, then a <a href="#rebase-response">§ 2.3.3 New Fon
 the client to replace the version they have with the newer version. The replacement font must cover
 at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    </ul>
-   <h5 class="heading settled" data-level="2.3.2.2" id="client-base-mismatch"><span class="secno">2.3.2.2. </span><span class="content">Client’s Base does not Match Server’s</span><a class="self-link" href="#client-base-mismatch"></a></h5>
-   <p>Over time servers may upgrade or change the way they compute subsets of fonts. This could result in
-the base font that a server computes not matching the base font that a client has. This case can be
-detected by the server by comparing <a href="#PatchRequest"><code>PatchRequest.base_checksum</code></a> to the checksum for the base that the server computed. If there is a mismatch the server should respond
-with a <a href="#rebase-response">§ 2.3.3 New Font Response</a> instead of the usual <a href="#patch-response">§ 2.3.4 Patch Font Response</a>. The replacement font must cover
-at minimum the codepoints specified in the <code>codepoints_have/indices_have</code> and <code>codepoints_needed/indices_needed</code> fields.</p>
    <h5 class="heading settled" data-level="2.3.2.3" id="codepoint-reordering-mismatch"><span class="secno">2.3.2.3. </span><span class="content">Client Codepoint Reordering does not Match Servers</span><a class="self-link" href="#codepoint-reordering-mismatch"></a></h5>
    <p>The codepoint mapping used by the client may not be recognized by the server. This case can be
 detected by comparing <a href="#PatchRequest"><code>PatchRequest.ordering_checksum</code></a> to a


### PR DESCRIPTION
- Remove the response_type field from responses. This is now inferred by the client based on which fields are set/unset.
- Unify handling of patch and rebase in the client (treats rebase as a patch against a zero length file).
- Adds specification for expected server behaviour. This is intentionally very minimal to give server implementations plenty of flexibility.